### PR TITLE
1.13 assets

### DIFF
--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -177,7 +177,8 @@ macro_rules! define_blocks {
                             $($fname,)*
                         } => {
                             $(return String::from($variant);)*
-                            "normal".to_owned()
+                            //"normal".to_owned()
+                            "".to_owned()
                         }
                     )+
                 }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -5143,7 +5143,7 @@ define_blocks! {
         },
         data Some(facing.horizontal_index()),
         offset Some(facing.horizontal_offset()),
-        model { ("minecraft", "silver_glazed_terracotta") },
+        model { ("minecraft", "light_gray_glazed_terracotta") },
         variant format!("facing={}", facing.as_string()),
     }
     CyanGlazedTerracotta {

--- a/resources/assets/steven/blockstates/missing_block.json
+++ b/resources/assets/steven/blockstates/missing_block.json
@@ -1,5 +1,5 @@
 {
     "variants": {
-        "normal": { "model": "missing_block" }
+        "": { "model": "missing_block" }
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -278,8 +278,15 @@ impl Factory {
         let file = match self.resources.read().unwrap().open(plugin, &format!("models/block/{}.json", model_name)) {
             Some(val) => val,
             None => {
-                error!("Couldn't find model {}", format!("models/block/{}.json", model_name));
-                return None;
+                // 1.13+ paths remove implicit blocks/
+                // TODO: remove fallback, look for specific asset version?
+                match self.resources.read().unwrap().open(plugin, &format!("models/{}.json", model_name)) {
+                    Some(val) => val,
+                    None => {
+                        error!("Couldn't find model models/block/{}.json or models/{}.json", model_name, model_name);
+                        return None;
+                    }
+                }
             },
         };
         let block_model: serde_json::Value = try_log!(opt serde_json::from_reader(file));

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -30,10 +30,10 @@ use zip;
 use crate::types::hash::FNVHash;
 use crate::ui;
 
-const RESOURCES_VERSION: &str = "1.12.2";
-const VANILLA_CLIENT_URL: &str = "https://launcher.mojang.com/v1/objects/0f275bc1547d01fa5f56ba34bdc87d981ee12daf/client.jar";
-const ASSET_VERSION: &str = "1.12";
-const ASSET_INDEX_URL: &str = "https://launchermeta.mojang.com/mc/assets/1.12/67e29e024e664064c1f04c728604f83c24cbc218/1.12.json";
+const RESOURCES_VERSION: &str = "1.13.2";
+const VANILLA_CLIENT_URL: &str = "https://launcher.mojang.com/v1/objects/30bfe37a8db404db11c7edf02cb5165817afb4d9/client.jar";
+const ASSET_VERSION: &str = "1.13.1";
+const ASSET_INDEX_URL: &str = "https://launchermeta.mojang.com/mc/assets/1.13.1/1e710e31f3ce2fe262373b8cf5e054ee5955d904/1.13.1.json";
 
 pub trait Pack: Sync + Send {
     fn open(&self, name: &str) -> Option<Box<io::Read>>;


### PR DESCRIPTION
(moved from https://github.com/iceiix/steven/pull/71)

https://github.com/iceiix/steven/pull/67 added 1.13.2 protocol support (protocol version 404) as part of #18 enhancing protocol support, but to use the new blocks, it has to be updated to use the new 1.13.x assets as well

See changes in https://minecraft.gamepedia.com/1.13/Flattening#Block_and_Item_IDs