### PR TITLE
Replace trim_left_matches() (deprecated) for trim_start_matches()

### DIFF
--- a/src/protocol/mojang.rs
+++ b/src/protocol/mojang.rs
@@ -113,7 +113,7 @@ impl Profile {
             twos_compliment(&mut hash);
         }
         let hash_str = hash.iter().map(|b| format!("{:02x}", b)).collect::<Vec<String>>().join("");
-        let hash_val = hash_str.trim_left_matches('0');
+        let hash_val = hash_str.trim_start_matches('0');
         let hash_str = if negative {
             "-".to_owned() + &hash_val[..]
         } else {


### PR DESCRIPTION
In the latest Rust nightly, `trim_left_matches()` is deprecated and replaced with `trim_start_matches()`, causing a warning when compiling. The functions are exactly the same otherwise.