### PR TITLE
Forge 1.8.9-1.12.2 handshake protocol support

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1170,6 +1170,23 @@ impl Conn {
                 }
             }
         }
+        // Forge 1.13+
+        if let Some(forge_data) = val.get("forgeData") {
+            if let Some(mods) = forge_data.get("mods") {
+                if let Value::Array(items) = mods {
+                    for item in items {
+                        if let Value::Object(obj) = item {
+                            let modid = obj.get("modId").unwrap().as_str().unwrap().to_string();
+                            let modmarker = obj.get("modmarker").unwrap().as_str().unwrap().to_string();
+
+                            let version = modmarker;
+
+                            forge_mods.push(crate::protocol::forge::ForgeMod { modid, version });
+                        }
+                    }
+                }
+            }
+        }
 
         Ok((Status {
             version: StatusVersion {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1170,23 +1170,6 @@ impl Conn {
                 }
             }
         }
-        // Forge 1.13+
-        if let Some(forge_data) = val.get("forgeData") {
-            if let Some(mods) = forge_data.get("mods") {
-                if let Value::Array(items) = mods {
-                    for item in items {
-                        if let Value::Object(obj) = item {
-                            let modid = obj.get("modId").unwrap().as_str().unwrap().to_string();
-                            let modmarker = obj.get("modmarker").unwrap().as_str().unwrap().to_string();
-
-                            let version = modmarker;
-
-                            forge_mods.push(crate::protocol::forge::ForgeMod { modid, version });
-                        }
-                    }
-                }
-            }
-        }
 
         Ok((Status {
             version: StatusVersion {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -723,7 +723,6 @@ impl Server {
                         }
                         // TODO: dynamically register mod blocks
                     },
-
                     HandshakeAck { phase } => {
                         match phase {
                             WaitingCAck => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -108,7 +108,8 @@ impl Server {
     pub fn connect(resources: Arc<RwLock<resources::Manager>>, profile: mojang::Profile, address: &str, protocol_version: i32, forge_mods: Vec<forge::ForgeMod>) -> Result<Server, protocol::Error> {
         let mut conn = protocol::Conn::new(address, protocol_version)?;
 
-        let host = conn.host.clone();
+        let tag = if forge_mods.len() != 0 { "\0FML\0" } else { "" };
+        let host = conn.host.clone() + tag;
         let port = conn.port;
         conn.write_packet(protocol::packet::handshake::serverbound::Handshake {
              protocol_version: protocol::VarInt(protocol_version),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -718,7 +718,7 @@ impl Server {
                     RegistryData { has_more, name, ids: _, substitutions: _, dummies: _ } => {
                         println!("Received FML|HS RegistryData for {}", name);
                         if !has_more {
-                            self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerData });
+                            self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });
                         }
                         // TODO: dynamically register mod blocks
                     },

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -712,7 +712,7 @@ impl Server {
                     },
                     ModIdData { mappings: _, block_substitutions: _, item_substitutions: _ } => {
                         println!("Received FML|HS ModIdData");
-                        self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerData });
+                        self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });
                         // TODO: dynamically register mod blocks
                     },
                     RegistryData { has_more, name, ids: _, substitutions: _, dummies: _ } => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -711,8 +711,18 @@ impl Server {
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerData });
                     },
                     ModIdData { mappings: _, block_substitutions: _, item_substitutions: _ } => {
+                        println!("Received FML|HS ModIdData");
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerData });
+                        // TODO: dynamically register mod blocks
                     },
+                    RegistryData { has_more, name, ids: _, substitutions: _, dummies: _ } => {
+                        println!("Received FML|HS RegistryData for {}", name);
+                        if !has_more {
+                            self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerData });
+                        }
+                        // TODO: dynamically register mod blocks
+                    },
+
                     HandshakeAck { phase } => {
                         match phase {
                             WaitingCAck => {


### PR DESCRIPTION
#134 #88 added Forge 1.7.10 handshake support, but 1.8.9 and later uses slightly different handshakes




