### PR TITLE
Fix packet compression. Closes #146

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1020,6 +1020,12 @@ impl Conn {
             VarInt(uncompressed_size as i32).write_to(&mut new)?;
             let mut write = ZlibEncoder::new(io::Cursor::new(buf), Compression::default());
             write.read_to_end(&mut new)?;
+            let network_debug = unsafe { NETWORK_DEBUG };
+            if network_debug {
+                println!("Compressed {} bytes to {} since > threshold {}, new={:?}",
+                         uncompressed_size, new.len(), self.compression_threshold,
+                         new);
+            }
             buf = new;
         }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1016,31 +1016,16 @@ impl Conn {
             0
         };
         if self.compression_threshold >= 0 && buf.len() as i32 > self.compression_threshold {
-            println!("Compressing since threshold={} > len={}", self.compression_threshold, buf.len());
             if self.compression_write.is_none() {
                 self.compression_write = Some(ZlibEncoder::new(io::Cursor::new(Vec::new()), Compression::default()));
-                println!("Initialized self.compression_write");
-            } else {
-                println!("Not initializing self.compression_write, was already");
             }
-
             extra = 0;
             let uncompressed_size = buf.len();
             let mut new = Vec::new();
-            //VarInt(uncompressed_size as i32).write_to(&mut new)?;
+            VarInt(uncompressed_size as i32).write_to(&mut new)?;
             let write = self.compression_write.as_mut().unwrap();
-            println!("Compressing buf={:?}", buf);
             write.reset(io::Cursor::new(buf));
             write.read_to_end(&mut new)?;
-            println!("Compressed bytes={:?}", new);
-            println!("About to decompress");
-            {
-                let mut reader = ZlibDecoder::new(&new[..]);
-                let mut check = Vec::new();
-                reader.read_to_end(&mut check).unwrap();
-                println!("Decompressed bytes={:?}", check);
-            }
-
             buf = new;
         }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1016,15 +1016,18 @@ impl Conn {
             0
         };
         if self.compression_threshold >= 0 && buf.len() as i32 > self.compression_threshold {
+            /*
             if self.compression_write.is_none() {
                 self.compression_write = Some(ZlibEncoder::new(io::Cursor::new(Vec::new()), Compression::default()));
             }
+            */
             extra = 0;
             let uncompressed_size = buf.len();
             let mut new = Vec::new();
             VarInt(uncompressed_size as i32).write_to(&mut new)?;
-            let write = self.compression_write.as_mut().unwrap();
-            write.reset(io::Cursor::new(buf));
+            //let write = self.compression_write.as_mut().unwrap();
+            //write.reset(io::Cursor::new(buf));
+            let mut write = ZlibEncoder::new(buf.as_slice(), Compression::default());
             write.read_to_end(&mut new)?;
             buf = new;
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1016,16 +1016,31 @@ impl Conn {
             0
         };
         if self.compression_threshold >= 0 && buf.len() as i32 > self.compression_threshold {
+            println!("Compressing since threshold={} > len={}", self.compression_threshold, buf.len());
             if self.compression_write.is_none() {
                 self.compression_write = Some(ZlibEncoder::new(io::Cursor::new(Vec::new()), Compression::default()));
+                println!("Initialized self.compression_write");
+            } else {
+                println!("Not initializing self.compression_write, was already");
             }
+
             extra = 0;
             let uncompressed_size = buf.len();
             let mut new = Vec::new();
-            VarInt(uncompressed_size as i32).write_to(&mut new)?;
+            //VarInt(uncompressed_size as i32).write_to(&mut new)?;
             let write = self.compression_write.as_mut().unwrap();
+            println!("Compressing buf={:?}", buf);
             write.reset(io::Cursor::new(buf));
             write.read_to_end(&mut new)?;
+            println!("Compressed bytes={:?}", new);
+            println!("About to decompress");
+            {
+                let mut reader = ZlibDecoder::new(&new[..]);
+                let mut check = Vec::new();
+                reader.read_to_end(&mut check).unwrap();
+                println!("Decompressed bytes={:?}", check);
+            }
+
             buf = new;
         }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -973,7 +973,6 @@ pub struct Conn {
 
     compression_threshold: i32,
     compression_read: Option<ZlibDecoder<io::Cursor<Vec<u8>>>>,
-    compression_write: Option<ZlibEncoder<io::Cursor<Vec<u8>>>>,
 }
 
 impl Conn {
@@ -1001,7 +1000,6 @@ impl Conn {
             cipher: Option::None,
             compression_threshold: -1,
             compression_read: Option::None,
-            compression_write: Option::None,
         })
     }
 
@@ -1016,18 +1014,11 @@ impl Conn {
             0
         };
         if self.compression_threshold >= 0 && buf.len() as i32 > self.compression_threshold {
-            /*
-            if self.compression_write.is_none() {
-                self.compression_write = Some(ZlibEncoder::new(io::Cursor::new(Vec::new()), Compression::default()));
-            }
-            */
             extra = 0;
             let uncompressed_size = buf.len();
             let mut new = Vec::new();
             VarInt(uncompressed_size as i32).write_to(&mut new)?;
-            //let write = self.compression_write.as_mut().unwrap();
-            //write.reset(io::Cursor::new(buf));
-            let mut write = ZlibEncoder::new(buf.as_slice(), Compression::default());
+            let mut write = ZlibEncoder::new(io::Cursor::new(buf), Compression::default());
             write.read_to_end(&mut new)?;
             buf = new;
         }
@@ -1278,7 +1269,6 @@ impl Clone for Conn {
             cipher: Option::None,
             compression_threshold: self.compression_threshold,
             compression_read: Option::None,
-            compression_write: Option::None,
         }
     }
 }


### PR DESCRIPTION
#146 1.12.2/1.10.2 Forge: Beyond/Skyfactory3/SevTech Ages crashes: error: StringError("failed to fill whole buffer") / java.util.zip.DataFormatException: incorrect header check