### PR TITLE
Modded block demo

### DIFF
--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -162,14 +162,16 @@ macro_rules! define_blocks {
                         block
                     } else {
                         let data = id & 0xf;
-                        println!("Looking up custom block id {}:{}", id >> 4, data);
+                        //println!("Looking up custom block id {}:{}", id >> 4, data); // could be unimplemented vanilla
 
                         if let Some(name) = modded_block_ids.get(&(id >> 4)) {
                             println!("Resolved modded block id {}:{} -> {}", id >> 4, data, name);
-                            VANILLA_ID_MAP.modded
-                                .get(name)
-                                .unwrap()[data]
-                                .unwrap_or(Block::Missing{})
+                            if let Some(blocks_by_data) = VANILLA_ID_MAP.modded.get(name) {
+                                blocks_by_data[data].unwrap_or(Block::Missing{})
+                            } else {
+                                println!("Modded block not supported yet: {}:{} -> {}", id >> 4, data, name);
+                                Block::Missing{}
+                            }
                         } else {
                             Block::Missing{}
                         }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -157,7 +157,8 @@ macro_rules! define_blocks {
                     // rockwool -> wool
                     // TODO: avoid hardcoding ids, lookup from ModIdData
                     if id >> 4 == 3731 {
-                        return VANILLA_ID_MAP.hier.get((35 << 4) | (id & 0xf)).and_then(|v| *v).unwrap()
+                        // TODO: correct variant from id & 0xf
+                        return Block::Rockwool { color: ColoredVariant::Orange }
                     }
 
                     VANILLA_ID_MAP.hier.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -142,6 +142,22 @@ macro_rules! define_blocks {
                 }
             }
 
+            #[allow(unused_variables, unreachable_code)]
+            pub fn get_modid(&self) -> Option<&str> {
+                match *self {
+                    $(
+                        Block::$name {
+                            $($fname,)*
+                        } => {
+                            $(
+                                return Some($modid);
+                            )*
+                            None
+                        }
+                    )+
+                }
+            }
+
             pub fn by_vanilla_id(id: usize, protocol_version: i32) -> Block {
                 if protocol_version >= 404 {
                     VANILLA_ID_MAP.flat.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -156,18 +156,23 @@ macro_rules! define_blocks {
             pub fn by_vanilla_id(id: usize, protocol_version: i32) -> Block {
                 if protocol_version >= 404 {
                     VANILLA_ID_MAP.flat.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})
+                    // TODO: support modded 1.13.2+ blocks after https://github.com/iceiix/stevenarella/pull/145
                 } else {
-                    // rockwool -> wool
-                    // TODO: avoid hardcoding ids, lookup from ModIdData
-                    if id >> 4 == 3731 {
-                        let data = id & 0xf;
-                        return VANILLA_ID_MAP.modded
-                            .get("\u{1}ThermalExpansion:Rockwool")
-                            .unwrap()[data]
-                            .unwrap_or(Block::Missing{})
+                    if let Some(block) = VANILLA_ID_MAP.hier.get(id).and_then(|v| *v) {
+                        block
+                    } else {
+                        // rockwool -> wool
+                        // TODO: avoid hardcoding ids, lookup from ModIdData
+                        if id >> 4 == 3731 {
+                            let data = id & 0xf;
+                            return VANILLA_ID_MAP.modded
+                                .get("\u{1}ThermalExpansion:Rockwool")
+                                .unwrap()[data]
+                                .unwrap_or(Block::Missing{})
+                        } else {
+                            Block::Missing{}
+                        }
                     }
-
-                    VANILLA_ID_MAP.hier.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})
                 }
             }
 

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -1060,7 +1060,7 @@ define_blocks! {
         data Some(color.data()),
         model { ("minecraft", format!("{}_wool", color.as_string()) ) },
     }
-    Rockwool {
+    ThermalExpansionRockwool {
         modid "ThermalExpansion:Rockwool",
         props {
             color: ColoredVariant = [
@@ -1085,7 +1085,31 @@ define_blocks! {
         data Some(color.data()),
         model { ("minecraft", format!("{}_wool", color.as_string()) ) },
     }
-
+    ThermalFoundationRockwool {
+        modid "thermalfoundation:rockwool",
+        props {
+            color: ColoredVariant = [
+                ColoredVariant::White,
+                ColoredVariant::Orange,
+                ColoredVariant::Magenta,
+                ColoredVariant::LightBlue,
+                ColoredVariant::Yellow,
+                ColoredVariant::Lime,
+                ColoredVariant::Pink,
+                ColoredVariant::Gray,
+                ColoredVariant::Silver,
+                ColoredVariant::Cyan,
+                ColoredVariant::Purple,
+                ColoredVariant::Blue,
+                ColoredVariant::Brown,
+                ColoredVariant::Green,
+                ColoredVariant::Red,
+                ColoredVariant::Black
+            ],
+        },
+        data Some(color.data()),
+        model { ("minecraft", format!("{}_wool", color.as_string()) ) },
+    }
     PistonExtension {
         props {
             facing: Direction = [

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -50,6 +50,7 @@ macro_rules! define_blocks {
     (
         $(
             $name:ident {
+                $(modid $modid:expr,)*
                 props {
                     $(
                         $fname:ident : $ftype:ty = [$($val:expr),+],
@@ -103,6 +104,10 @@ macro_rules! define_blocks {
                             $($fname,)*
                         } => {
                             $(
+                                $modid;
+                                return None;
+                            )*
+                            $(
                                 let data: Option<usize> = ($datafunc).map(|v| v);
                                 return data;
                             )*
@@ -119,6 +124,10 @@ macro_rules! define_blocks {
                         Block::$name {
                             $($fname,)*
                         } => {
+                            $(
+                                $modid;
+                                return None;
+                            )*
                             $(
                                 let offset: Option<usize> = ($offsetfunc).map(|v| v);
                                 return offset;
@@ -1020,6 +1029,32 @@ define_blocks! {
         data Some(color.data()),
         model { ("minecraft", format!("{}_wool", color.as_string()) ) },
     }
+    Rockwool {
+        modid "\u{1}ThermalExpansion:Rockwool",
+        props {
+            color: ColoredVariant = [
+                ColoredVariant::White,
+                ColoredVariant::Orange,
+                ColoredVariant::Magenta,
+                ColoredVariant::LightBlue,
+                ColoredVariant::Yellow,
+                ColoredVariant::Lime,
+                ColoredVariant::Pink,
+                ColoredVariant::Gray,
+                ColoredVariant::Silver,
+                ColoredVariant::Cyan,
+                ColoredVariant::Purple,
+                ColoredVariant::Blue,
+                ColoredVariant::Brown,
+                ColoredVariant::Green,
+                ColoredVariant::Red,
+                ColoredVariant::Black
+            ],
+        },
+        data Some(color.data()),
+        model { ("minecraft", format!("{}_wool", color.as_string()) ) },
+    }
+
     PistonExtension {
         props {
             facing: Direction = [

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -45,8 +45,7 @@ macro_rules! create_ids {
 struct VanillaIDMap {
     flat: Vec<Option<Block>>,
     hier: Vec<Option<Block>>,
-    //modded: HashMap<&'static str, [Option<Block>; 16]>, // TODO: fixed-size array?
-    modded: HashMap<String, Vec<Option<Block>>>,
+    modded: HashMap<String, [Option<Block>; 16]>,
 }
 
 macro_rules! define_blocks {
@@ -296,7 +295,7 @@ macro_rules! define_blocks {
             static ref VANILLA_ID_MAP: VanillaIDMap = {
                 let mut blocks_flat = vec![];
                 let mut blocks_hier = vec![];
-                let mut blocks_modded: HashMap<String, Vec<Option<Block>>> = HashMap::new();
+                let mut blocks_modded: HashMap<String, [Option<Block>; 16]> = HashMap::new();
                 let mut flat_id = 0;
                 let mut last_internal_id = 0;
                 let mut hier_block_id = 0;
@@ -396,7 +395,7 @@ macro_rules! define_blocks {
                         if let Some(modid) = block.get_modid() {
                             let hier_data = hier_data.unwrap();
                             if !blocks_modded.contains_key(modid) {
-                                blocks_modded.insert(modid.to_string(), vec![None; 16]);
+                                blocks_modded.insert(modid.to_string(), [None; 16]);
                             }
                             let block_from_data = blocks_modded.get_mut(modid).unwrap();
                             block_from_data[hier_data] = Some(block);

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! define_blocks {
                         //println!("Looking up custom block id {}:{}", id >> 4, data); // could be unimplemented vanilla
 
                         if let Some(name) = modded_block_ids.get(&(id >> 4)) {
-                            println!("Resolved modded block id {}:{} -> {}", id >> 4, data, name);
+                            //println!("Resolved modded block id {}:{} -> {}", id >> 4, data, name);
                             if let Some(blocks_by_data) = VANILLA_ID_MAP.modded.get(name) {
                                 blocks_by_data[data].unwrap_or(Block::Missing{})
                             } else {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -161,15 +161,12 @@ macro_rules! define_blocks {
                         block
                     } else {
                         let data = id & 0xf;
-                        //println!("Looking up custom block id {}:{}", id >> 4, data); // could be unimplemented vanilla
 
                         if let Some(name) = modded_block_ids.get(&(id >> 4)) {
-                            //println!("Resolved modded block id {}:{} -> {:?}", id >> 4, data, name);
-                            //println!("modded = {:?}", VANILLA_ID_MAP.modded);
                             if let Some(blocks_by_data) = VANILLA_ID_MAP.modded.get(name) {
                                 blocks_by_data[data].unwrap_or(Block::Missing{})
                             } else {
-                                println!("Modded block not supported yet: {}:{} -> {}", id >> 4, data, name);
+                                //println!("Modded block not supported yet: {}:{} -> {}", id >> 4, data, name);
                                 Block::Missing{}
                             }
                         } else {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -394,7 +394,6 @@ macro_rules! define_blocks {
                         let internal_id = block.get_internal_id();
                         let hier_data: Option<usize> = block.get_hierarchical_data();
                         if let Some(modid) = block.get_modid() {
-                            println!("Mod id: {}, hier_data {:?}", modid, hier_data);
                             let hier_data = hier_data.unwrap();
                             if !blocks_modded.contains_key(modid) {
                                 blocks_modded.insert(modid.to_string(), vec![None; 16]);

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -104,10 +104,6 @@ macro_rules! define_blocks {
                             $($fname,)*
                         } => {
                             $(
-                                $modid;
-                                return None;
-                            )*
-                            $(
                                 let data: Option<usize> = ($datafunc).map(|v| v);
                                 return data;
                             )*
@@ -124,10 +120,6 @@ macro_rules! define_blocks {
                         Block::$name {
                             $($fname,)*
                         } => {
-                            $(
-                                $modid;
-                                return None;
-                            )*
                             $(
                                 let offset: Option<usize> = ($offsetfunc).map(|v| v);
                                 return offset;
@@ -384,6 +376,10 @@ macro_rules! define_blocks {
                     for block in iter {
                         let internal_id = block.get_internal_id();
                         let hier_data: Option<usize> = block.get_hierarchical_data();
+                        if let Some(_modid) = block.get_modid() {
+                            continue
+                        }
+
                         let vanilla_id =
                             if let Some(hier_data) = hier_data {
                                 if internal_id != last_internal_id {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -137,6 +137,12 @@ macro_rules! define_blocks {
                 if protocol_version >= 404 {
                     VANILLA_ID_MAP.flat.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})
                 } else {
+                    // rockwool -> wool
+                    // TODO: avoid hardcoding ids, lookup from ModIdData
+                    if id >> 4 == 3731 {
+                        return VANILLA_ID_MAP.hier.get((35 << 4) | (id & 0xf)).and_then(|v| *v).unwrap()
+                    }
+
                     VANILLA_ID_MAP.hier.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})
                 }
             }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -153,7 +153,7 @@ macro_rules! define_blocks {
                 }
             }
 
-            pub fn by_vanilla_id(id: usize, protocol_version: i32) -> Block {
+            pub fn by_vanilla_id(id: usize, protocol_version: i32, modded_block_ids: &HashMap<usize, String>) -> Block {
                 if protocol_version >= 404 {
                     VANILLA_ID_MAP.flat.get(id).and_then(|v| *v).unwrap_or(Block::Missing{})
                     // TODO: support modded 1.13.2+ blocks after https://github.com/iceiix/stevenarella/pull/145
@@ -161,12 +161,13 @@ macro_rules! define_blocks {
                     if let Some(block) = VANILLA_ID_MAP.hier.get(id).and_then(|v| *v) {
                         block
                     } else {
-                        // rockwool -> wool
-                        // TODO: avoid hardcoding ids, lookup from ModIdData
-                        if id >> 4 == 3731 {
-                            let data = id & 0xf;
-                            return VANILLA_ID_MAP.modded
-                                .get("\u{1}ThermalExpansion:Rockwool")
+                        let data = id & 0xf;
+                        println!("Looking up custom block id {}:{}", id >> 4, data);
+
+                        if let Some(name) = modded_block_ids.get(&(id >> 4)) {
+                            println!("Resolved modded block id {}:{} -> {}", id >> 4, data, name);
+                            VANILLA_ID_MAP.modded
+                                .get(name)
                                 .unwrap()[data]
                                 .unwrap_or(Block::Missing{})
                         } else {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -1061,7 +1061,7 @@ define_blocks! {
         model { ("minecraft", format!("{}_wool", color.as_string()) ) },
     }
     Rockwool {
-        modid "\u{2}ThermalExpansion:Rockwool",
+        modid "ThermalExpansion:Rockwool",
         props {
             color: ColoredVariant = [
                 ColoredVariant::White,

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -165,7 +165,8 @@ macro_rules! define_blocks {
                         //println!("Looking up custom block id {}:{}", id >> 4, data); // could be unimplemented vanilla
 
                         if let Some(name) = modded_block_ids.get(&(id >> 4)) {
-                            //println!("Resolved modded block id {}:{} -> {}", id >> 4, data, name);
+                            //println!("Resolved modded block id {}:{} -> {:?}", id >> 4, data, name);
+                            //println!("modded = {:?}", VANILLA_ID_MAP.modded);
                             if let Some(blocks_by_data) = VANILLA_ID_MAP.modded.get(name) {
                                 blocks_by_data[data].unwrap_or(Block::Missing{})
                             } else {
@@ -1065,7 +1066,7 @@ define_blocks! {
         model { ("minecraft", format!("{}_wool", color.as_string()) ) },
     }
     Rockwool {
-        modid "\u{1}ThermalExpansion:Rockwool",
+        modid "\u{2}ThermalExpansion:Rockwool",
         props {
             color: ColoredVariant = [
                 ColoredVariant::White,

--- a/src/protocol/forge.rs
+++ b/src/protocol/forge.rs
@@ -85,31 +85,8 @@ impl Serializable for ModIdMapping {
     }
 }
 
-pub static BLOCK_NAMESPACE: u8 = 1;
-pub static ITEM_NAMESPACE: u8 = 2;
-
-#[derive(Debug)]
-pub struct NamespacedModIdMapping {
-    pub namespace: u8,
-    pub name: String,
-    pub id: VarInt,
-}
-
-impl Serializable for NamespacedModIdMapping {
-    fn read_from<R: io::Read>(buf: &mut R) -> Result<Self, Error> {
-        Ok(NamespacedModIdMapping {
-            namespace: Serializable::read_from(buf)?,
-            name: Serializable::read_from(buf)?,
-            id: Serializable::read_from(buf)?,
-        })
-    }
-
-    fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
-        self.namespace.write_to(buf)?;
-        self.name.write_to(buf)?;
-        self.id.write_to(buf)
-    }
-}
+pub static BLOCK_NAMESPACE: &'static str = "\u{1}";
+pub static ITEM_NAMESPACE: &'static str = "\u{2}";
 
 #[derive(Debug)]
 pub enum FmlHs {
@@ -131,7 +108,7 @@ pub enum FmlHs {
         dummies: LenPrefixed<VarInt, String>,
     },
     ModIdData {
-        mappings: LenPrefixed<VarInt, NamespacedModIdMapping>,
+        mappings: LenPrefixed<VarInt, ModIdMapping>,
         block_substitutions: LenPrefixed<VarInt, String>,
         item_substitutions: LenPrefixed<VarInt, String>,
     },

--- a/src/protocol/forge.rs
+++ b/src/protocol/forge.rs
@@ -85,6 +85,32 @@ impl Serializable for ModIdMapping {
     }
 }
 
+pub static BLOCK_NAMESPACE: u8 = 1;
+pub static ITEM_NAMESPACE: u8 = 2;
+
+#[derive(Debug)]
+pub struct NamespacedModIdMapping {
+    pub namespace: u8,
+    pub name: String,
+    pub id: VarInt,
+}
+
+impl Serializable for NamespacedModIdMapping {
+    fn read_from<R: io::Read>(buf: &mut R) -> Result<Self, Error> {
+        Ok(NamespacedModIdMapping {
+            namespace: Serializable::read_from(buf)?,
+            name: Serializable::read_from(buf)?,
+            id: Serializable::read_from(buf)?,
+        })
+    }
+
+    fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
+        self.namespace.write_to(buf)?;
+        self.name.write_to(buf)?;
+        self.id.write_to(buf)
+    }
+}
+
 #[derive(Debug)]
 pub enum FmlHs {
     ServerHello {
@@ -105,7 +131,7 @@ pub enum FmlHs {
         dummies: LenPrefixed<VarInt, String>,
     },
     ModIdData {
-        mappings: LenPrefixed<VarInt, ModIdMapping>,
+        mappings: LenPrefixed<VarInt, NamespacedModIdMapping>,
         block_substitutions: LenPrefixed<VarInt, String>,
         item_substitutions: LenPrefixed<VarInt, String>,
     },

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1294,7 +1294,7 @@ impl Server {
     }
 
     fn on_block_change(&mut self, location: Position, id: i32) {
-        self.world.set_block(location, block::Block::by_vanilla_id(id as usize, self.protocol_version))
+        self.world.set_block(location, self.world.by_vanilla_id(id as usize))
     }
 
     fn on_block_change_varint(&mut self, block_change: packet::play::clientbound::BlockChange_VarInt) {
@@ -1318,7 +1318,7 @@ impl Server {
                     record.y as i32,
                     oz + (record.xz & 0xF) as i32
                 ),
-                block::Block::by_vanilla_id(record.block_id.0 as usize, self.protocol_version)
+                self.world.by_vanilla_id(record.block_id.0 as usize)
             );
         }
     }
@@ -1341,7 +1341,7 @@ impl Server {
 
             self.world.set_block(
                 Position::new(x, y, z),
-                block::Block::by_vanilla_id(id as usize, self.protocol_version)
+                self.world.by_vanilla_id(id as usize)
             );
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -279,12 +279,13 @@ impl Server {
         entities.add_component(world_entity, game_info, entity::GameInfo::new());
 
         let version = resources.read().unwrap().version();
+        let modded_block_ids = HashMap::new();
         Server {
             uuid,
             conn,
             protocol_version,
             forge_mods,
-            modded_block_ids: HashMap::new(),
+            modded_block_ids,
             read_queue,
             disconnect_reason: None,
             just_disconnected: false,
@@ -716,7 +717,8 @@ impl Server {
                     ModIdData { mappings, block_substitutions: _, item_substitutions: _ } => {
                         println!("Received FML|HS ModIdData");
                         for m in mappings.data {
-                            self.modded_block_ids.insert(m.id.0 as usize, m.name);
+                            self.modded_block_ids.insert(m.id.0 as usize, m.name.clone()); // TODO: avoid unnecessary clone
+                            self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
                         }
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });
                         // TODO: dynamically register mod blocks
@@ -725,7 +727,8 @@ impl Server {
                         println!("Received FML|HS RegistryData for {}", name);
                         if name == "minecraft:blocks" {
                             for m in ids.data {
-                                self.modded_block_ids.insert(m.id.0 as usize, m.name);
+                                self.modded_block_ids.insert(m.id.0 as usize, m.name.clone());
+                                self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
                             }
                         }
                         if !has_more {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -717,9 +717,11 @@ impl Server {
                     ModIdData { mappings, block_substitutions: _, item_substitutions: _ } => {
                         println!("Received FML|HS ModIdData");
                         for m in mappings.data {
-                            if m.namespace == protocol::forge::BLOCK_NAMESPACE {
-                                self.modded_block_ids.insert(m.id.0 as usize, m.name.clone()); // TODO: avoid unnecessary clone
-                                self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
+                            let (namespace, name) = m.name.split_at(1);
+                            if namespace == protocol::forge::BLOCK_NAMESPACE {
+                                // TODO: avoid unnecessary clone()
+                                self.modded_block_ids.insert(m.id.0 as usize, name.to_string().clone());
+                                self.world.modded_block_ids.insert(m.id.0 as usize, name.to_string());
                             }
                         }
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -717,8 +717,10 @@ impl Server {
                     ModIdData { mappings, block_substitutions: _, item_substitutions: _ } => {
                         println!("Received FML|HS ModIdData");
                         for m in mappings.data {
-                            self.modded_block_ids.insert(m.id.0 as usize, m.name.clone()); // TODO: avoid unnecessary clone
-                            self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
+                            if m.namespace == protocol::forge::BLOCK_NAMESPACE {
+                                self.modded_block_ids.insert(m.id.0 as usize, m.name.clone()); // TODO: avoid unnecessary clone
+                                self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
+                            }
                         }
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });
                     },

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -721,7 +721,6 @@ impl Server {
                             self.world.modded_block_ids.insert(m.id.0 as usize, m.name);
                         }
                         self.write_fmlhs_plugin_message(&HandshakeAck { phase: WaitingServerComplete });
-                        // TODO: dynamically register mod blocks
                     },
                     RegistryData { has_more, name, ids, substitutions: _, dummies: _ } => {
                         println!("Received FML|HS RegistryData for {}", name);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1294,7 +1294,7 @@ impl Server {
     }
 
     fn on_block_change(&mut self, location: Position, id: i32) {
-        self.world.set_block(location, self.world.by_vanilla_id(id as usize))
+        self.world.set_block(location, block::Block::by_vanilla_id(id as usize, self.protocol_version))
     }
 
     fn on_block_change_varint(&mut self, block_change: packet::play::clientbound::BlockChange_VarInt) {
@@ -1318,7 +1318,7 @@ impl Server {
                     record.y as i32,
                     oz + (record.xz & 0xF) as i32
                 ),
-                self.world.by_vanilla_id(record.block_id.0 as usize)
+                block::Block::by_vanilla_id(record.block_id.0 as usize, self.protocol_version)
             );
         }
     }
@@ -1341,7 +1341,7 @@ impl Server {
 
             self.world.set_block(
                 Position::new(x, y, z),
-                self.world.by_vanilla_id(id as usize)
+                block::Block::by_vanilla_id(id as usize, self.protocol_version)
             );
         }
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -88,10 +88,6 @@ impl World {
         }
     }
 
-    pub fn by_vanilla_id(&self, id: usize) -> block::Block {
-        block::Block::by_vanilla_id(id, self.protocol_version)
-    }
-
     pub fn is_chunk_loaded(&self, x: i32, z: i32) -> bool {
         self.chunks.contains_key(&CPos(x, z))
     }
@@ -623,7 +619,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = data.read_u16::<byteorder::LittleEndian>()?;
-                    section.blocks.set(bi, self.by_vanilla_id(id as usize));
+                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -809,7 +805,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = ((block_add[i].get(bi) as u16) << 12) | ((block_types[i][bi] as u16) << 4) | (block_meta[i].get(bi) as u16);
-                    section.blocks.set(bi, self.by_vanilla_id(id as usize));
+                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -886,7 +882,7 @@ impl World {
                     let count = VarInt::read_from(&mut data)?.0;
                     for i in 0 .. count {
                         let id = VarInt::read_from(&mut data)?.0;
-                        let bl = self.by_vanilla_id(id as usize);
+                        let bl = block::Block::by_vanilla_id(id as usize, self.protocol_version);
                         mappings.insert(i as usize, bl);
                     }
                 }
@@ -896,7 +892,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = m.get(bi);
-                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(self.by_vanilla_id(id)));
+                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(block::Block::by_vanilla_id(id, self.protocol_version)));
                     // Spawn block entities
                     let b = section.blocks.get(bi);
                     if block_entity::BlockEntityType::get_block_entity(b).is_some() {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -45,7 +45,7 @@ pub struct World {
     block_entity_actions: VecDeque<BlockEntityAction>,
 
     protocol_version: i32,
-    modded_block_ids: HashMap<usize, String>,
+    pub modded_block_ids: HashMap<usize, String>, // TODO: reference with lifetime parameter to avoid copying from server module
 }
 
 #[derive(Clone, Debug)]

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -45,7 +45,7 @@ pub struct World {
     block_entity_actions: VecDeque<BlockEntityAction>,
 
     protocol_version: i32,
-    pub modded_block_ids: HashMap<usize, String>, // TODO: reference with lifetime parameter to avoid copying from server module
+    pub modded_block_ids: HashMap<usize, String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -88,6 +88,10 @@ impl World {
         }
     }
 
+    pub fn by_vanilla_id(&self, id: usize) -> block::Block {
+        block::Block::by_vanilla_id(id, self.protocol_version)
+    }
+
     pub fn is_chunk_loaded(&self, x: i32, z: i32) -> bool {
         self.chunks.contains_key(&CPos(x, z))
     }
@@ -619,7 +623,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = data.read_u16::<byteorder::LittleEndian>()?;
-                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
+                    section.blocks.set(bi, self.by_vanilla_id(id as usize));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -805,7 +809,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = ((block_add[i].get(bi) as u16) << 12) | ((block_types[i][bi] as u16) << 4) | (block_meta[i].get(bi) as u16);
-                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
+                    section.blocks.set(bi, self.by_vanilla_id(id as usize));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -882,7 +886,7 @@ impl World {
                     let count = VarInt::read_from(&mut data)?.0;
                     for i in 0 .. count {
                         let id = VarInt::read_from(&mut data)?.0;
-                        let bl = block::Block::by_vanilla_id(id as usize, self.protocol_version);
+                        let bl = self.by_vanilla_id(id as usize);
                         mappings.insert(i as usize, bl);
                     }
                 }
@@ -892,7 +896,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = m.get(bi);
-                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(block::Block::by_vanilla_id(id, self.protocol_version)));
+                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(self.by_vanilla_id(id)));
                     // Spawn block entities
                     let b = section.blocks.get(bi);
                     if block_entity::BlockEntityType::get_block_entity(b).is_some() {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -45,6 +45,7 @@ pub struct World {
     block_entity_actions: VecDeque<BlockEntityAction>,
 
     protocol_version: i32,
+    modded_block_ids: HashMap<usize, String>,
 }
 
 #[derive(Clone, Debug)]
@@ -619,7 +620,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = data.read_u16::<byteorder::LittleEndian>()?;
-                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
+                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version, &self.modded_block_ids));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -805,7 +806,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = ((block_add[i].get(bi) as u16) << 12) | ((block_types[i][bi] as u16) << 4) | (block_meta[i].get(bi) as u16);
-                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version));
+                    section.blocks.set(bi, block::Block::by_vanilla_id(id as usize, self.protocol_version, &self.modded_block_ids));
 
                     // Spawn block entities
                     let b = section.blocks.get(bi);
@@ -882,7 +883,7 @@ impl World {
                     let count = VarInt::read_from(&mut data)?.0;
                     for i in 0 .. count {
                         let id = VarInt::read_from(&mut data)?.0;
-                        let bl = block::Block::by_vanilla_id(id as usize, self.protocol_version);
+                        let bl = block::Block::by_vanilla_id(id as usize, self.protocol_version, &self.modded_block_ids);
                         mappings.insert(i as usize, bl);
                     }
                 }
@@ -892,7 +893,7 @@ impl World {
 
                 for bi in 0 .. 4096 {
                     let id = m.get(bi);
-                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(block::Block::by_vanilla_id(id, self.protocol_version)));
+                    section.blocks.set(bi, mappings.get(&id).cloned().unwrap_or(block::Block::by_vanilla_id(id, self.protocol_version, &self.modded_block_ids)));
                     // Spawn block entities
                     let b = section.blocks.get(bi);
                     if block_entity::BlockEntityType::get_block_entity(b).is_some() {


### PR DESCRIPTION
Add minimal support for a simple modded block

The chosen block to support: https://ftb.gamepedia.com/Rockwool_(Thermal_Expansion_3)

- [x] Forge handshake support and parsing (#88 #134 #144)
- [x] Enhance steven_blocks macro to label block `modid`
- [x] Define a simple easily implementable modded block (ThermalExpansion:Rockwool)
- [x] Add modid lookup if id not in vanilla, split metadata
- [x] Link ModIdData/RegistryData to supported modded block modid lookup, removing hardcoded id
- [x] Test on 1.7.10 + forge 10.13.4.1614 + ThermalExpansion-[1.7.10]4.1.5-248 
- [x] Test on 1.10.2 + FTB Beyond 1.11.0
- [x] Test on 1.12.2 + forge 1.12.2-14.23.5.2815 + CoFHCore-1.12.2-4.6.2.25 + CoFHWorld-1.12.2-1.3.0.6 + CodeChickenLib-1.12.2-3.2.2.353 + RedstoneFlux-1.12-2.1.0.6 + ThermalExpansion-1.12.2-5.5.3.41 + ThermalFoundation-1.12.2-2.6.2.26