### PR TITLE
Update to glutin 0.21.0. Closes #157

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,16 +659,6 @@ dependencies = [
 
 [[package]]
 name = "gl_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gl_generator"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -677,25 +677,68 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.19.0"
-source = "git+https://github.com/iceiix/glutin?rev=de52fba20678f3931fba3eb6700774469e48512f#de52fba20678f3931fba3eb6700774469e48512f"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_egl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_emscripten_sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_gles2_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_glx_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_wgl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.21.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.1 (git+http://github.com/iceiix/winit?branch=wasm_stub)",
+ "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glutin_emscripten_sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glutin_gles2_sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1815,7 +1858,7 @@ dependencies = [
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.19.0 (git+https://github.com/iceiix/glutin?rev=de52fba20678f3931fba3eb6700774469e48512f)",
+ "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2353,8 +2396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winit"
-version = "0.18.1"
-source = "git+http://github.com/iceiix/winit?branch=wasm_stub#dad2ea4d13e3a43fb1ff135c0fdc1c79919d4c8e"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2495,6 +2538,7 @@ dependencies = [
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
+"checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b92dfd5c2f75260cbf750572f95d387e7ca0ba5e3fbe9e1a33f23025be020f"
@@ -2516,11 +2560,15 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4bca55ac1f213920ce3527ccd62386f1f15fa3f1714aeee1cf93f2c416903f"
-"checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
-"checksum glutin 0.19.0 (git+https://github.com/iceiix/glutin?rev=de52fba20678f3931fba3eb6700774469e48512f)" = "<none>"
+"checksum glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb26027a84c3b9e1949ef0df0b6a3db8d0c124243a5c161ea25c7def90cb1474"
+"checksum glutin_egl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "23f48987ab6cb2b61ad903b59e54a2fd0c380a7baff68cffd6826b69a73dd326"
+"checksum glutin_emscripten_sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "245b3fdb08df6ffed7585365851f8404af9c7e2dd4b59f15262e968b6a95a0c7"
+"checksum glutin_gles2_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89996c30857ae1b4de4b5189abf1ea822a20a9fe9e1c93e5e7b862ff0bdd5cdf"
+"checksum glutin_glx_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1290a5ca5e46fcfa7f66f949cc9d9194b2cb6f2ed61892c8c2b82343631dba57"
+"checksum glutin_wgl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f801bbc91efc22dd1c4818a47814fc72bf74d024510451b119381579bfa39021"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -2700,7 +2748,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.18.1 (git+http://github.com/iceiix/winit?branch=wasm_stub)" = "<none>"
+"checksum winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d233301129ddd33260b47f76900b50e154b7254546e2edba0e5468a1a5fe4de3"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11-clipboard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a77356335a1398267e15a7c1d5fa1c8d3fdb3e5ba2e381407d74482c29587d3"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,11 +686,11 @@ dependencies = [
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_egl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_emscripten_sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_gles2_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_glx_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_wgl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -698,13 +698,13 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.21.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (git+https://github.com/iceiix/winit?branch=wasm_stub)",
 ]
 
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -713,12 +713,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1858,7 +1858,7 @@ dependencies = [
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2396,8 +2396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winit"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.18.1"
+source = "git+https://github.com/iceiix/winit?branch=wasm_stub#dad2ea4d13e3a43fb1ff135c0fdc1c79919d4c8e"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,12 +2563,12 @@ dependencies = [
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
-"checksum glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb26027a84c3b9e1949ef0df0b6a3db8d0c124243a5c161ea25c7def90cb1474"
-"checksum glutin_egl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "23f48987ab6cb2b61ad903b59e54a2fd0c380a7baff68cffd6826b69a73dd326"
-"checksum glutin_emscripten_sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "245b3fdb08df6ffed7585365851f8404af9c7e2dd4b59f15262e968b6a95a0c7"
-"checksum glutin_gles2_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89996c30857ae1b4de4b5189abf1ea822a20a9fe9e1c93e5e7b862ff0bdd5cdf"
-"checksum glutin_glx_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1290a5ca5e46fcfa7f66f949cc9d9194b2cb6f2ed61892c8c2b82343631dba57"
-"checksum glutin_wgl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f801bbc91efc22dd1c4818a47814fc72bf74d024510451b119381579bfa39021"
+"checksum glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -2748,7 +2748,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d233301129ddd33260b47f76900b50e154b7254546e2edba0e5468a1a5fe4de3"
+"checksum winit 0.18.1 (git+https://github.com/iceiix/winit?branch=wasm_stub)" = "<none>"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11-clipboard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a77356335a1398267e15a7c1d5fa1c8d3fdb3e5ba2e381407d74482c29587d3"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.21.0"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,11 +686,11 @@ dependencies = [
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
- "glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
- "glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
- "glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
- "glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -698,13 +698,13 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.21.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.1 (git+https://github.com/iceiix/winit?branch=wasm_stub)",
+ "winit 0.19.1 (git+https://github.com/iceiix/winit?rev=0e0ebeb34656dda53e0961638521b18a24254b78)",
 ]
 
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -713,12 +713,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.0"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.5"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd#5f490a9ffec1e1facbdad2264585301e8a5927cd"
+source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1858,7 +1858,7 @@ dependencies = [
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)",
+ "glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2396,8 +2396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winit"
-version = "0.18.1"
-source = "git+https://github.com/iceiix/winit?branch=wasm_stub#dad2ea4d13e3a43fb1ff135c0fdc1c79919d4c8e"
+version = "0.19.1"
+source = "git+https://github.com/iceiix/winit?rev=0e0ebeb34656dda53e0961638521b18a24254b78#0e0ebeb34656dda53e0961638521b18a24254b78"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,12 +2563,12 @@ dependencies = [
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
-"checksum glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
-"checksum glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
-"checksum glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
-"checksum glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
-"checksum glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
-"checksum glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5f490a9ffec1e1facbdad2264585301e8a5927cd)" = "<none>"
+"checksum glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -2748,7 +2748,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.18.1 (git+https://github.com/iceiix/winit?branch=wasm_stub)" = "<none>"
+"checksum winit 0.19.1 (git+https://github.com/iceiix/winit?rev=0e0ebeb34656dda53e0961638521b18a24254b78)" = "<none>"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11-clipboard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a77356335a1398267e15a7c1d5fa1c8d3fdb3e5ba2e381407d74482c29587d3"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.21.0"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,11 +686,11 @@ dependencies = [
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
- "glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
- "glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
- "glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
- "glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
+ "glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
+ "glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
+ "glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
+ "glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -713,12 +713,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.0"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.5"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.3"
-source = "git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f#43c166146f6999afc99a2159c872b1dabd2e877f"
+source = "git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c#5ff18dec039f6854091685980d7213858a8aaa4c"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1858,7 +1858,7 @@ dependencies = [
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)",
+ "glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,12 +2563,12 @@ dependencies = [
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
-"checksum glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
-"checksum glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
-"checksum glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
-"checksum glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
-"checksum glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
-"checksum glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=43c166146f6999afc99a2159c872b1dabd2e877f)" = "<none>"
+"checksum glutin 0.21.0 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
+"checksum glutin_egl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
+"checksum glutin_emscripten_sys 0.1.0 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
+"checksum glutin_gles2_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
+"checksum glutin_glx_sys 0.1.5 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
+"checksum glutin_wgl_sys 0.1.3 (git+https://github.com/iceiix/glutin?rev=5ff18dec039f6854091685980d7213858a8aaa4c)" = "<none>"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ opt-level = 1
 cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"
 sha-1 = "0.8.1"
-glutin = "0.21.0"
+#glutin = { git = "https://github.com/iceiix/glutin", branch = "wasm_stub" }
+glutin = { git = "https://github.com/iceiix/glutin", rev = "5f490a9ffec1e1facbdad2264585301e8a5927cd" }
 byteorder = "1.2.7"
 serde = "1.0.91"
 serde_json = "1.0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"
 sha-1 = "0.8.1"
 #glutin = { git = "https://github.com/iceiix/glutin", branch = "wasm_stub" }
-glutin = { git = "https://github.com/iceiix/glutin", rev = "5f490a9ffec1e1facbdad2264585301e8a5927cd" }
+glutin = { git = "https://github.com/iceiix/glutin", rev = "43c166146f6999afc99a2159c872b1dabd2e877f" }
 byteorder = "1.2.7"
 serde = "1.0.91"
 serde_json = "1.0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ opt-level = 1
 cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"
 sha-1 = "0.8.1"
-#glutin = { git = "https://github.com/iceiix/glutin", branch = "wasm_stub" }
 glutin = { git = "https://github.com/iceiix/glutin", rev = "5ff18dec039f6854091685980d7213858a8aaa4c" }
 byteorder = "1.2.7"
 serde = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"
 sha-1 = "0.8.1"
 #glutin = { git = "https://github.com/iceiix/glutin", branch = "wasm_stub" }
-glutin = { git = "https://github.com/iceiix/glutin", rev = "43c166146f6999afc99a2159c872b1dabd2e877f" }
+glutin = { git = "https://github.com/iceiix/glutin", rev = "5ff18dec039f6854091685980d7213858a8aaa4c" }
 byteorder = "1.2.7"
 serde = "1.0.91"
 serde_json = "1.0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ opt-level = 1
 cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"
 sha-1 = "0.8.1"
-glutin = { git = "https://github.com/iceiix/glutin", rev = "de52fba20678f3931fba3eb6700774469e48512f" }
+glutin = "0.21.0"
 byteorder = "1.2.7"
 serde = "1.0.91"
 serde_json = "1.0.39"

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 extern crate steven_gl as gl;
-use glutin::ContextTrait;
 
 use std::ops::BitOr;
 use std::ffi;

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use std::ops::{Deref, DerefMut};
 
 /// Inits the gl library. This should be called once a context is ready.
-pub fn init(vid: & glutin::WindowedContext) {
+pub fn init<T>(vid: & glutin::WindowedContext<T>) where T: glutin::ContextCurrentState {
     gl::load_with(|s| vid.get_proc_address(s) as *const _);
 }
 

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use std::ops::{Deref, DerefMut};
 
 /// Inits the gl library. This should be called once a context is ready.
-pub fn init<T>(vid: & glutin::WindowedContext<T>) where T: glutin::ContextCurrentState {
+pub fn init(vid: & glutin::WindowedContext<glutin::PossiblyCurrent>) {
     gl::load_with(|s| vid.get_proc_address(s) as *const _);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ use std::thread;
 use std::sync::mpsc;
 use crate::protocol::mojang;
 use glutin;
-use glutin::ContextTrait;
 
 const CL_BRAND: console::CVar<String> = console::CVar {
     ty: PhantomData,

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ pub fn main() {
     }
 
     let textures = renderer.get_textures();
-    let dpi_factor = window.get_current_monitor().get_hidpi_factor();
+    let dpi_factor = window.window().get_current_monitor().get_hidpi_factor();
     let default_protocol_version = protocol::versions::protocol_name_to_protocol_version(
         opt.default_protocol_version.unwrap_or("".to_string()));
     let mut game = Game {
@@ -297,8 +297,8 @@ pub fn main() {
         let diff = now.duration_since(last_frame);
         last_frame = now;
         let delta = (diff.subsec_nanos() as f64) / frame_time;
-        let (width, height) = window.get_inner_size().unwrap().into();
-        let (physical_width, physical_height) = window.get_inner_size().unwrap().to_physical(game.dpi_factor).into();
+        let (width, height) = window.window().get_inner_size().unwrap().into();
+        let (physical_width, physical_height) = window.window().get_inner_size().unwrap().to_physical(game.dpi_factor).into();
 
         let version = {
             let try_res = game.resource_manager.try_write();
@@ -381,8 +381,8 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                 use std::f64::consts::PI;
 
                 if game.focused {
-                    window.grab_cursor(true).unwrap();
-                    window.hide_cursor(true);
+                    window.window().grab_cursor(true).unwrap();
+                    window.window().hide_cursor(true);
                     if let Some(player) = game.server.player {
                         let rotation = game.server.entities.get_component_mut(player, game.server.rotation).unwrap();
                         rotation.yaw -= rx;
@@ -395,8 +395,8 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                         }
                     }
                 } else {
-                    window.grab_cursor(false).unwrap();
-                    window.hide_cursor(false);
+                    window.window().grab_cursor(false).unwrap();
+                    window.window().hide_cursor(false);
                 }
             },
 
@@ -406,8 +406,8 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
         Event::WindowEvent{event, ..} => match event {
             WindowEvent::CloseRequested => game.should_close = true,
             WindowEvent::Resized(logical_size) => {
-                game.dpi_factor = window.get_hidpi_factor();
-                window.resize(logical_size.to_physical(game.dpi_factor));
+                game.dpi_factor = window.window().get_hidpi_factor();
+                window.window().resize(logical_size.to_physical(game.dpi_factor));
             },
 
             WindowEvent::ReceivedCharacter(codepoint) => {
@@ -419,17 +419,17 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
             WindowEvent::MouseInput{device_id: _, state, button, modifiers: _} => {
                 match (state, button) {
                     (ElementState::Released, MouseButton::Left) => {
-                        let (width, height) = window.get_inner_size().unwrap().into();
+                        let (width, height) = window.window().get_inner_size().unwrap().into();
 
                         if game.server.is_connected() && !game.focused && !game.screen_sys.is_current_closable() {
                             game.focused = true;
-                            window.grab_cursor(true).unwrap();
-                            window.hide_cursor(true);
+                            window.window().grab_cursor(true).unwrap();
+                            window.window().hide_cursor(true);
                             return;
                         }
                         if !game.focused {
-                            window.grab_cursor(false).unwrap();
-                            window.hide_cursor(false);
+                            window.window().grab_cursor(false).unwrap();
+                            window.window().hide_cursor(false);
                             ui_container.click_at(game, game.last_mouse_x, game.last_mouse_y, width, height);
                         }
                     },
@@ -447,7 +447,7 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                 game.last_mouse_y = y;
 
                 if !game.focused {
-                    let (width, height) = window.get_inner_size().unwrap().into();
+                    let (width, height) = window.window().get_inner_size().unwrap().into();
                     ui_container.hover_at(game, x, y, width, height);
                 }
             },
@@ -467,13 +467,13 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                 match (input.state, input.virtual_keycode) {
                     (ElementState::Released, Some(VirtualKeyCode::Escape)) => {
                         if game.focused {
-                            window.grab_cursor(false).unwrap();
-                            window.hide_cursor(false);
+                            window.window().grab_cursor(false).unwrap();
+                            window.window().hide_cursor(false);
                             game.focused = false;
                             game.screen_sys.replace_screen(Box::new(screen::SettingsMenu::new(game.vars.clone(), true)));
                         } else if game.screen_sys.is_current_closable() {
-                            window.grab_cursor(true).unwrap();
-                            window.hide_cursor(true);
+                            window.window().grab_cursor(true).unwrap();
+                            window.window().hide_cursor(true);
                             game.focused = true;
                             game.screen_sys.pop_screen();
                         }
@@ -483,9 +483,9 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                     },
                     (ElementState::Pressed, Some(VirtualKeyCode::F11)) => {
                         if !game.is_fullscreen {
-                            window.set_fullscreen(Some(window.get_current_monitor()));
+                            window.window().set_fullscreen(Some(window.window().get_current_monitor()));
                         } else {
-                            window.set_fullscreen(None);
+                            window.window().set_fullscreen(None);
                         }
 
                         game.is_fullscreen = !game.is_fullscreen;

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,7 @@ fn handle_window_event(window: &mut glutin::WindowedContext<glutin::PossiblyCurr
             WindowEvent::CloseRequested => game.should_close = true,
             WindowEvent::Resized(logical_size) => {
                 game.dpi_factor = window.window().get_hidpi_factor();
-                window.window().resize(logical_size.to_physical(game.dpi_factor));
+                window.resize(logical_size.to_physical(game.dpi_factor));
             },
 
             WindowEvent::ReceivedCharacter(codepoint) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,13 +223,13 @@ pub fn main() {
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Stevenarella")
         .with_dimensions(glutin::dpi::LogicalSize::new(854.0, 480.0));
-    let context = glutin::ContextBuilder::new()
+    let mut window = glutin::ContextBuilder::new()
         .with_stencil_buffer(0)
         .with_depth_buffer(24)
         .with_gl(glutin::GlRequest::GlThenGles{opengl_version: (3, 2), opengles_version: (2, 0)})
         .with_gl_profile(glutin::GlProfile::Core)
-        .with_vsync(vsync);
-    let mut window = glutin::WindowedContext::new(window_builder, context, &events_loop)
+        .with_vsync(vsync)
+        .build_windowed(window_builder, &events_loop)
         .expect("Could not create glutin window.");
 
     unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ pub fn main() {
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Stevenarella")
         .with_dimensions(glutin::dpi::LogicalSize::new(854.0, 480.0));
-    let mut window = glutin::ContextBuilder::new()
+    let window = glutin::ContextBuilder::new()
         .with_stencil_buffer(0)
         .with_depth_buffer(24)
         .with_gl(glutin::GlRequest::GlThenGles{opengl_version: (3, 2), opengles_version: (2, 0)})
@@ -232,9 +232,9 @@ pub fn main() {
         .build_windowed(window_builder, &events_loop)
         .expect("Could not create glutin window.");
 
-    unsafe {
-        window.make_current().expect("Could not set current context.");
-    }
+    let window = unsafe {
+        window.make_current().expect("Could not set current context.")
+    };
 
     gl::init(&window);
 
@@ -354,10 +354,10 @@ pub fn main() {
     }
 }
 
-fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
+fn handle_window_event(window: &mut glutin::WindowedContext<glutin::PossiblyCurrent>,
                        game: &mut Game,
                        ui_container: &mut ui::Container,
-                       event: glutin::Event) where T: glutin::ContextCurrentState {
+                       event: glutin::Event) {
     use glutin::*;
     match event {
         Event::DeviceEvent{event, ..} => match event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,10 +354,10 @@ pub fn main() {
     }
 }
 
-fn handle_window_event(window: &mut glutin::WindowedContext,
+fn handle_window_event<T>(window: &mut glutin::WindowedContext<T>,
                        game: &mut Game,
                        ui_container: &mut ui::Container,
-                       event: glutin::Event) {
+                       event: glutin::Event) where T: glutin::ContextCurrentState {
     use glutin::*;
     match event {
         Event::DeviceEvent{event, ..} => match event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ pub fn main() {
         .build_windowed(window_builder, &events_loop)
         .expect("Could not create glutin window.");
 
-    let window = unsafe {
+    let mut window = unsafe {
         window.make_current().expect("Could not set current context.")
     };
 


### PR DESCRIPTION
Closes https://github.com/iceiix/stevenarella/issues/157

Glutin v0.21.0 migration guide: https://gentz.rocks/posts/glutin-v0-21-0-migration-guide/
