### PR TITLE
Attempt to fix Travis-CI timeouts due to build caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       - env: WASM=false
 cache:
     cargo: true
-    timeout: 1000
+    timeout: 10000
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo chown root:wheel /usr/local/bin/brew ; fi


### PR DESCRIPTION
AppVeyor is working but Travis-CI is always failing some builds:

example: https://travis-ci.org/iceiix/stevenarella/builds/539101869?utm_source=github_status&utm_medium=notification

<img width="1204" alt="Screen Shot 2019-05-30 at 3 45 58 PM" src="https://user-images.githubusercontent.com/43691553/58669805-05a66c00-82f2-11e9-9e20-395f15a6396e.png">

```
Setting up build cache
$ export CASHER_DIR=${TRAVIS_HOME}/.casher
0.14s$ Installing caching utilities
0.00s43.17sattempting to download cache archive
fetching structopt-0.2.16/cache-linux-trusty-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--cargo-stable.tgz
fetching structopt-0.2.16/cache--cargo-stable.tgz
fetching dependabotcargostructopt-0.2.16/cache-linux-trusty-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--cargo-stable.tgz
fetching dependabotcargostructopt-0.2.16/cache--cargo-stable.tgz
fetching master/cache-linux-trusty-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--cargo-stable.tgz
found cache
0.00sadding /home/travis/.cargo to cache
creating directory /home/travis/.cargo
adding /home/travis/build/iceiix/stevenarella/target to cache
creating directory /home/travis/build/iceiix/stevenarella/target
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```