### PR TITLE
Fix SpawnPainting parsing 1.13.2-1.14.4, closes #212

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -201,8 +201,6 @@ cfg_if! {
     }
 }
 
-use std::fs;
-use std::io::Read;
 fn main2() {
     let opt = Opt::from_args();
 
@@ -216,15 +214,6 @@ fn main2() {
     log::set_max_level(log::LevelFilter::Trace);
 
     info!("Starting steven");
-
-    println!("open");
-    let mut file = fs::File::open("last-packet").unwrap();
-    //let mut buf = vec![];
-    //file.read_to_end(&mut buf).unwrap();
-    println!("about to parse");
-    let packet = crate::protocol::packet::packet_by_id(498, crate::protocol::State::Play, crate::protocol::Direction::Clientbound, 0x04, &mut file);
-    println!("packet = {:?}", packet);
-    return;
 
     let (vars, vsync) = {
         let mut vars = console::Vars::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,8 @@ cfg_if! {
     }
 }
 
+use std::fs;
+use std::io::Read;
 fn main2() {
     let opt = Opt::from_args();
 
@@ -214,6 +216,15 @@ fn main2() {
     log::set_max_level(log::LevelFilter::Trace);
 
     info!("Starting steven");
+
+    println!("open");
+    let mut file = fs::File::open("last-packet").unwrap();
+    //let mut buf = vec![];
+    //file.read_to_end(&mut buf).unwrap();
+    println!("about to parse");
+    let packet = crate::protocol::packet::packet_by_id(498, crate::protocol::State::Play, crate::protocol::Direction::Clientbound, 0x04, &mut file);
+    println!("packet = {:?}", packet);
+    return;
 
     let (vars, vsync) = {
         let mut vars = console::Vars::new();

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -619,7 +619,14 @@ state_packets!(
             }
             /// SpawnPainting spawns a painting into the world when it is in range of
             /// the client. The title effects the size and the texture of the painting.
-            packet SpawnPainting {
+            packet SpawnPainting_VarInt {
+                field entity_id: VarInt =,
+                field uuid: UUID =,
+                field motive: VarInt =,
+                field location: Position =,
+                field direction: u8 =,
+            }
+            packet SpawnPainting_String {
                 field entity_id: VarInt =,
                 field uuid: UUID =,
                 field title: String =,

--- a/src/protocol/versions/v18w50a.rs
+++ b/src/protocol/versions/v18w50a.rs
@@ -57,7 +57,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v19w02a.rs
+++ b/src/protocol/versions/v19w02a.rs
@@ -57,7 +57,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_10_2.rs
+++ b/src/protocol/versions/v1_10_2.rs
@@ -44,7 +44,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob_u8
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_11_2.rs
+++ b/src/protocol/versions/v1_11_2.rs
@@ -44,7 +44,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_12_2.rs
+++ b/src/protocol/versions/v1_12_2.rs
@@ -47,7 +47,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_13_2.rs
+++ b/src/protocol/versions/v1_13_2.rs
@@ -57,7 +57,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_14.rs
+++ b/src/protocol/versions/v1_14.rs
@@ -60,7 +60,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_14_1.rs
+++ b/src/protocol/versions/v1_14_1.rs
@@ -60,7 +60,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_14_2.rs
+++ b/src/protocol/versions/v1_14_2.rs
@@ -60,7 +60,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_14_3.rs
+++ b/src/protocol/versions/v1_14_3.rs
@@ -60,7 +60,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_14_4.rs
+++ b/src/protocol/versions/v1_14_4.rs
@@ -60,7 +60,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_VarInt
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_9.rs
+++ b/src/protocol/versions/v1_9.rs
@@ -44,7 +44,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob_u8
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics

--- a/src/protocol/versions/v1_9_2.rs
+++ b/src/protocol/versions/v1_9_2.rs
@@ -44,7 +44,7 @@ protocol_packet_ids!(
             0x01 => SpawnExperienceOrb
             0x02 => SpawnGlobalEntity
             0x03 => SpawnMob_u8
-            0x04 => SpawnPainting
+            0x04 => SpawnPainting_String
             0x05 => SpawnPlayer_f64
             0x06 => Animation
             0x07 => Statistics


### PR DESCRIPTION
The packet changed in 1.13.2 but wasn't updated, so we split the packet
variants into SpawnPainting_String for the old version and
SpawnPainting_VarInt for the new version with a 'motive' VarInt field
instead of a String title. Fixes #212 World won't load: FromUtf8Error { bytes: [255, 255, 183, 63, 255, 253, 224, 87, 3], error: Utf8Error

1.9-1.12.2 SpawnPainting_String: https://wiki.vg/index.phptitle=Protocol&oldid=14204#Spawn_Painting

1.13.2-1.14.4 SpawnPainting_VarInt: https://wiki.vg/index.phptitle=Protocol&oldid=14889#Spawn_Painting