### PR TITLE
blocks: split macro into multiple functions, fast!

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -12,10 +12,9 @@ tasks:
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
       sh ./rustup.sh -y
       source $HOME/.cargo/env
-      rustup install nightly
-      cargo +nightly --version
+      cargo --version
   - build: |
       source $HOME/.cargo/env
       cd stevenarella
-      cargo +nightly build
-      cargo +nightly test
+      cargo build
+      cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ path = "src/main.rs"
 # Use an -O1 optimization level strikes a good compromise between build and program performance.
 opt-level = 1
 
-[profile.release.package.steven_blocks]
-opt-level = 1
-
 [dependencies]
 cfg-if = "0.1.9"
 wasm-bindgen = "0.2.44"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Visual Studio 2017 Redistributable is required to run these builds.
 
 ## Building
 
-Requires Rust nightly version `rustc 1.42.0-nightly (760ce94c6 2020-01-04)` or newer to build.
+Requires Rust stable version 1.40.0 or newer to build.
 
 Compile and run:
 ```bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ build_script:
 
     appveyor AddMessage "Platform rust: %RUST_INSTALL%"
 
-    appveyor DownloadFile "https://static.rust-lang.org/dist/rust-nightly-%RUST_INSTALL%.exe" -FileName rust-install.exe
+    appveyor DownloadFile "https://static.rust-lang.org/dist/rust-1.40.0-%RUST_INSTALL%.exe" -FileName rust-install.exe
 
     "./rust-install.exe" /VERYSILENT /NORESTART /DIR="C:\Rust\"
 

--- a/blocks/Cargo.toml
+++ b/blocks/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.0.1"
 authors = [ "Thinkofdeath <thinkofdeath@spigotmc.org>" ]
 edition = "2018"
 
-[profile.release]
-opt-level = 1
-
 [dependencies]
 lazy_static = "1.4.0"
 cgmath = "0.17.0"


### PR DESCRIPTION
Improves fix for #184, whereas #255 reduced optimizations,
we now address the underlying compiler limitation and split out
the one massive lazy_static! initialization function, into
one function per block in the block_registration_functions module.

Previous build time, with opt-level=1:

% time cargo build --release
   Compiling steven_blocks v0.0.1
    Finished release [optimized] target(s) in 21.24s
cargo build --release  31.80s user 0.71s system 152% cpu 21.276 total

With this change, opt-level=3 and the function splitting fix:

% time cargo build --release
   Compiling steven_blocks v0.0.1
    Finished release [optimized] target(s) in 30.80s
cargo build --release  40.26s user 0.86s system 133% cpu 30.850 total

Full optimizations are expectedly slightly slower, but this is still
much much _much_ faster than before this refactoring, where this crate
would take up to an unbelievable 5 hours (and tens of GB of RAM). Long
story short, we're now back to full optimizations and stable Rust.