### PR TITLE
Do not redraw until main events are cleared (Fixes unresponsiveness to input)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,12 @@ fn main2() {
 
     let mut last_resource_version = 0;
     events_loop.run(move |event, _event_loop, control_flow| {
+        *control_flow = glutin::event_loop::ControlFlow::Poll;
+
+        if !handle_window_event(&mut window, &mut game, &mut ui_container, event) {
+            return;
+        }
+
         let now = Instant::now();
         let diff = now.duration_since(last_frame);
         last_frame = now;
@@ -359,8 +365,6 @@ fn main2() {
         }
         window.swap_buffers().expect("Failed to swap GL buffers");
 
-        handle_window_event(&mut window, &mut game, &mut ui_container, event);
-
         if game.should_close {
             *control_flow = glutin::event_loop::ControlFlow::Exit;
         }
@@ -370,9 +374,10 @@ fn main2() {
 fn handle_window_event<T>(window: &mut glutin::WindowedContext<glutin::PossiblyCurrent>,
                        game: &mut Game,
                        ui_container: &mut ui::Container,
-                       event: glutin::event::Event<T>) {
+                       event: glutin::event::Event<T>) -> bool {
     use glutin::event::*;
     match event {
+        Event::MainEventsCleared => return true,
         Event::DeviceEvent{event, ..} => match event {
             DeviceEvent::ModifiersChanged(modifiers_state) => {
                 game.is_ctrl_pressed = modifiers_state.ctrl();
@@ -443,12 +448,12 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<glutin::PossiblyC
                             game.focused = true;
                             window.window().set_cursor_grab(true).unwrap();
                             window.window().set_cursor_visible(false);
-                            return;
-                        }
-                        if !game.focused {
-                            window.window().set_cursor_grab(false).unwrap();
-                            window.window().set_cursor_visible(true);
-                            ui_container.click_at(game, game.last_mouse_x, game.last_mouse_y, width, height);
+                        } else {
+                            if !game.focused {
+                                window.window().set_cursor_grab(false).unwrap();
+                                window.window().set_cursor_visible(true);
+                                ui_container.click_at(game, game.last_mouse_x, game.last_mouse_y, width, height);
+                            }
                         }
                     },
                     (ElementState::Pressed, MouseButton::Right) => {
@@ -538,4 +543,6 @@ fn handle_window_event<T>(window: &mut glutin::WindowedContext<glutin::PossiblyC
 
         _ => (),
     }
+
+    false
 }


### PR DESCRIPTION
This fixes the issue of events not being handled and the game becoming unresponsive. The main issue was that control_flow should be set to `ControlFlow::Poll` and only when the received event is matched to `Event::MainEventsCleared` should the screen be redrawn.