### PR TITLE
Fix crash when window gets minimized

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,6 @@ fn main2() {
         let delta = (diff.subsec_nanos() as f64) / frame_time;
         let (width, height) = window.window().inner_size().into();
         let (physical_width, physical_height) = window.window().inner_size().to_physical(game.dpi_factor).into();
-
         let version = {
             let try_res = game.resource_manager.try_write();
             if try_res.is_ok() {
@@ -351,6 +350,11 @@ fn main2() {
         game.tick(delta);
         game.server.tick(&mut game.renderer, delta);
 
+        // Check if window is valid, it might be minimized
+        if physical_width == 0 || physical_height == 0 {
+            return;
+        }
+
         game.renderer.update_camera(physical_width, physical_height);
         game.server.world.compute_render_list(&mut game.renderer);
         game.chunk_builder.tick(&mut game.server.world, &mut game.renderer, version);
@@ -362,7 +366,6 @@ fn main2() {
             .tick(&mut ui_container, &game.renderer, delta, width as f64);
         ui_container.tick(&mut game.renderer, delta, width as f64, height as f64);
         game.renderer.tick(&mut game.server.world, delta, width, height, physical_width, physical_height);
-
 
         if fps_cap > 0 && !vsync {
             let frame_time = now.elapsed();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -259,10 +259,13 @@ impl Renderer {
             self.height = height;
             gl::viewport(0, 0, width as i32, height as i32);
 
+            let fov = cgmath::Rad::from(cgmath::Deg(90.0_f32));
+            let aspect_ratio = (width as f32 / height as f32).max(1.0);
+
             self.perspective_matrix = cgmath::Matrix4::from(
                 cgmath::PerspectiveFov {
-                    fovy: cgmath::Rad::from(cgmath::Deg(90f32)),
-                    aspect: (width as f32 / height as f32),
+                    fovy: fov,
+                    aspect: aspect_ratio,
                     near: 0.1f32,
                     far: 500.0f32,
                 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -259,13 +259,13 @@ impl Renderer {
             self.height = height;
             gl::viewport(0, 0, width as i32, height as i32);
 
-            let fov = cgmath::Rad::from(cgmath::Deg(90.0_f32));
-            let aspect_ratio = (width as f32 / height as f32).max(1.0);
+            let fovy = cgmath::Rad::from(cgmath::Deg(90.0_f32));
+            let aspect = (width as f32 / height as f32).max(1.0);
 
             self.perspective_matrix = cgmath::Matrix4::from(
                 cgmath::PerspectiveFov {
-                    fovy: fov,
-                    aspect: aspect_ratio,
+                    fovy,
+                    aspect,
                     near: 0.1f32,
                     far: 500.0f32,
                 }


### PR DESCRIPTION
Implements a simple check of whether the window dimensions are valid. If the window dimensions are invalid, e.g. when the window is minimized, render calls are not done. The game state is updated regardless.

This fixes https://github.com/iceiix/stevenarella/issues/275