### PR TITLE
pub fields in struct Stack

### DIFF
--- a/protocol/src/item.rs
+++ b/protocol/src/item.rs
@@ -19,10 +19,10 @@ use std::io;
 
 #[derive(Debug)]
 pub struct Stack {
-    id: isize,
-    count: isize,
-    damage: Option<isize>,
-    tag: Option<nbt::NamedTag>,
+    pub id: isize,
+    pub count: isize,
+    pub damage: Option<isize>,
+    pub tag: Option<nbt::NamedTag>,
 }
 
 impl Default for Stack {


### PR DESCRIPTION
While doing experiments with the protocol library I encountered a problem with this struct, here I put the fields as pub so it can be used