### PR TITLE
Add CD via Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: (Linux/MacOS) Strip binary
         if: matrix.os != 'windows-latest'
         run: strip target/release/stevenarella
-      - name: Remove .d file for globbing
+      - name: Move binary
         run: |
           if [[ ${{ matrix.os }} == windows ]]; then
             mv target/release/stevenarella.exe .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         run: rm target/release/stevenarella.d
         shell: bash
       - name: Upload binary
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: stevenarella-${{ matrix.os }}
           path: target/release/stevenarella*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,9 +41,9 @@ jobs:
       - name: Move binary
         run: |
           if [[ ${{ matrix.os }} == windows ]]; then
-            mv target/release/stevenarella.exe .
+            mv target/release/stevenarella.exe stevenarella-${{ matrix.os }}.exe
           else
-            mv target/release/stevenarella .
+            mv target/release/stevenarella stevenarella-${{ matrix.os }}
           fi
         shell: bash
       - name: Upload binary

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,48 @@
+name: Build
+on:
+  push:
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: 
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+      - name: Enable static CRT linkage # https://stackoverflow.com/a/44387312/7653274
+        if: matrix.os == 'windows-latest'
+        run: |
+          mkdir .cargo
+          echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
+          echo 'rustflags = ["-Ctarget-feature=+crt-static"]' >> .cargo/config
+      - name: Build binary
+        run: |
+          cargo build --verbose --release
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.14
+      - name: Strip binary
+        if: matrix.os != 'windows-latest'
+        run: strip target/release/stevenarella
+      - name: Upload binary
+        uses: actions/upload-artifact@v1
+        with:
+          name: stevenarella-${{ matrix.os }}
+          path: target/release/stevenarella
+      - name: Release binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/release/stevenarella
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,16 +38,19 @@ jobs:
       - name: (Linux/MacOS) Strip binary
         if: matrix.os != 'windows-latest'
         run: strip target/release/stevenarella
+      - name: Remove .d file for globbing
+        run: rm target/release/stevenarella.d
+        shell: bash
       - name: Upload binary
         uses: actions/upload-artifact@v1
         with:
           name: stevenarella-${{ matrix.os }}
-          path: target/release/stevenarella
+          path: target/release/stevenarella*
       - name: Release binary
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/release/stevenarella
+            target/release/stevenarella*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,18 +39,23 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: strip target/release/stevenarella
       - name: Remove .d file for globbing
-        run: rm target/release/stevenarella.d
+        run: |
+          if [[ ${{ matrix.os }} == windows ]]; then
+            mv target/release/stevenarella.exe .
+          else
+            mv target/release/stevenarella .
+          fi
         shell: bash
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
           name: stevenarella-${{ matrix.os }}
-          path: target/release/stevenarella*
+          path: stevenarella*
       - name: Release binary
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/release/stevenarella*
+            stevenarella*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on:
   push:
 
 jobs:
-  linux:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,6 +25,11 @@ jobs:
           mkdir .cargo
           echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
           echo 'rustflags = ["-Ctarget-feature=+crt-static"]' >> .cargo/config
+      - name: Install libxcb-composite
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt install -y libxcb-composite0-dev
       - name: Build binary
         run: |
           cargo build --verbose --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,23 +19,23 @@ jobs:
         with:
           toolchain: stable
           default: true
-      - name: Enable static CRT linkage # https://stackoverflow.com/a/44387312/7653274
+      - name: (Windows) Enable static CRT linkage # https://stackoverflow.com/a/44387312/7653274
         if: matrix.os == 'windows-latest'
         run: |
           mkdir .cargo
           echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
           echo 'rustflags = ["-Ctarget-feature=+crt-static"]' >> .cargo/config
-      - name: Install libxcb-composite
+      - name: (Linux) Install libxcb-composite
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt update
-          sudo apt install -y libxcb-composite0-dev
+          sudo apt-get update
+          sudo apt-get install -y libxcb-composite0-dev
       - name: Build binary
         run: |
           cargo build --verbose --release
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.14
-      - name: Strip binary
+      - name: (Linux/MacOS) Strip binary
         if: matrix.os != 'windows-latest'
         run: strip target/release/stevenarella
       - name: Upload binary


### PR DESCRIPTION
Closes #93 

This PR adds a Github Actions workflow that builds binaries and publishes them [on the workflow page](https://github.com/MCOfficer/stevenarella/actions/runs/152436202). If the workflow runs on a tag, it will also publish [to the releases page](https://github.com/MCOfficer/stevenarella/releases/tag/test4).

The workflow runs on every new push, tag or release.