### PR TITLE
Strip whitespace from favicon data. Fixes #353

### DIFF
--- a/src/screen/server_list.rs
+++ b/src/screen/server_list.rs
@@ -266,6 +266,8 @@ impl ServerList {
                         format::convert_legacy(&mut desc);
                         let favicon = if let Some(icon) = res.0.favicon {
                             let data_base64 = &icon["data:image/png;base64,".len()..];
+                            let data_base64: String =
+                                data_base64.chars().filter(|c| !c.is_whitespace()).collect();
                             let data = base64::decode(data_base64).unwrap();
                             Some(image::load_from_memory(&data).unwrap())
                         } else {


### PR DESCRIPTION
Attempt at fixing #353 Favicon unzip thread panic while connecting to FTB beyond 1.11.0- Invalid byte (76, 10)
Not tested