### PR TITLE
Minor change: Don't consume self when writing packet to a writer. Mutability is not affected

### DIFF
--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -119,7 +119,7 @@ macro_rules! state_packets {
                             packet::versions::translate_internal_packet_id_for_version(version, State::$stateName, Direction::$dirName, internal_ids::$name, false)
                         }
 
-                        fn write<W: io::Write>(&mut self, buf: &mut W) -> Result<(), Error> {
+                        fn write<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
                             $(
                                 if true $(&& ($cond(&self)))* {
                                     self.$field.write_to(buf)?;
@@ -1065,7 +1065,7 @@ impl Conn {
         })
     }
 
-    pub fn write_packet<T: PacketType>(&mut self, mut packet: T) -> Result<(), Error> {
+    pub fn write_packet<T: PacketType>(&mut self, packet: T) -> Result<(), Error> {
         let mut buf = Vec::new();
         VarInt(packet.packet_id(self.protocol_version)).write_to(&mut buf)?;
         packet.write(&mut buf)?;
@@ -1387,5 +1387,5 @@ impl Clone for Conn {
 pub trait PacketType {
     fn packet_id(&self, protocol_version: i32) -> i32;
 
-    fn write<W: io::Write>(&mut self, buf: &mut W) -> Result<(), Error>;
+    fn write<W: io::Write>(&self, buf: &mut W) -> Result<(), Error>;
 }

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -119,7 +119,7 @@ macro_rules! state_packets {
                             packet::versions::translate_internal_packet_id_for_version(version, State::$stateName, Direction::$dirName, internal_ids::$name, false)
                         }
 
-                        fn write<W: io::Write>(self, buf: &mut W) -> Result<(), Error> {
+                        fn write<W: io::Write>(&mut self, buf: &mut W) -> Result<(), Error> {
                             $(
                                 if true $(&& ($cond(&self)))* {
                                     self.$field.write_to(buf)?;
@@ -1065,7 +1065,7 @@ impl Conn {
         })
     }
 
-    pub fn write_packet<T: PacketType>(&mut self, packet: T) -> Result<(), Error> {
+    pub fn write_packet<T: PacketType>(&mut self, mut packet: T) -> Result<(), Error> {
         let mut buf = Vec::new();
         VarInt(packet.packet_id(self.protocol_version)).write_to(&mut buf)?;
         packet.write(&mut buf)?;
@@ -1387,5 +1387,5 @@ impl Clone for Conn {
 pub trait PacketType {
     fn packet_id(&self, protocol_version: i32) -> i32;
 
-    fn write<W: io::Write>(self, buf: &mut W) -> Result<(), Error>;
+    fn write<W: io::Write>(&mut self, buf: &mut W) -> Result<(), Error>;
 }


### PR DESCRIPTION
Doing this would allow writing the packet to multiple streams without having to copy the packet to perform actions on it afterwards. As the current implementation doesn't strictly need the packet to consume itself this is no breaking change, but expands possibilities for PacketType implementors.

The following scenario now becomes possible:
* read packet
* &lt;do whatever with packet&gt; //Already possible
* write packet to stream
* &lt;do whatever with packet&gt; //Was not possible until now