### PR TITLE
Update the "glutin" crate to version 0.23.0 which fixes bug #384.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 1
 [dependencies]
 cfg-if = "0.1.9"
 wasm-bindgen = "0.2.68"
-glutin = "0.22.0"
+glutin = "0.23.0"
 byteorder = "1.3.4"
 serde = "1.0.116"
 serde_json = "1.0.56"


### PR DESCRIPTION
Tiny change.

This transitively updates the `winit` crate which solves the bug in the title.
See here for additional info about the bug fix in the `winit` crate: https://github.com/rust-windowing/winit/issues/1386 and https://github.com/rust-windowing/winit/issues/1425