### PR TITLE
1.16+: implement EntityEquipment_Array top-bit terminated variant

### DIFF
--- a/protocol/src/protocol/versions/v1_16_1.rs
+++ b/protocol/src/protocol/versions/v1_16_1.rs
@@ -128,7 +128,7 @@ protocol_packet_ids!(
             0x44 => EntityMetadata
             0x45 => EntityAttach
             0x46 => EntityVelocity
-            0x47 => EntityEquipment_VarInt // TODO: changed to an array, but earlier than 1.16.1
+            0x47 => EntityEquipment_Array
             0x48 => SetExperience
             0x49 => UpdateHealth
             0x4a => ScoreboardObjective

--- a/protocol/src/protocol/versions/v1_16_4.rs
+++ b/protocol/src/protocol/versions/v1_16_4.rs
@@ -129,7 +129,7 @@ protocol_packet_ids!(
             0x44 => EntityMetadata
             0x45 => EntityAttach
             0x46 => EntityVelocity
-            0x47 => EntityEquipment_VarInt // TODO: changed to an array, but earlier than 1.16.1
+            0x47 => EntityEquipment_Array
             0x48 => SetExperience
             0x49 => UpdateHealth
             0x4a => ScoreboardObjective


### PR DESCRIPTION
Fixes #408 1.16.1: EntityEquipment_VarInt : Main thread panic: Failed to read all of packet 0x47, had 363 bytes left - enchants
Fixes #421 1.16.1: EntityEquipment_VarInt : Player heads break things. (Failed to read all of packet 0x47, had 1292 bytes left)