### PR TITLE
Renderbuffer

### DIFF
--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -957,7 +957,37 @@ impl Framebuffer {
             gl::FramebufferTexture2D(gl::FRAMEBUFFER, attachment, target, tex.0, level);
         }
     }
+
+    pub fn renderbuffer(
+        &self,
+        attachment: Attachment,
+        rb: Renderbuffer,
+    ) {
+        unsafe {
+            gl::FramebufferRenderbuffer(gl::FRAMEBUFFER, attachment, gl::RENDERBUFFER, rb.0);
+        }
+    }
 }
+
+#[derive(Default)]
+pub struct Renderbuffer(u32);
+
+impl Renderbuffer {
+    pub fn new() -> Renderbuffer {
+        let mut rb = Renderbuffer(0);
+        unsafe {
+            gl::GenRenderbuffers(1, &mut rb.0)
+        }
+        rb
+    }
+
+    pub fn bind(&self) {
+        unsafe {
+            gl::BindRenderbuffer(gl::RENDERBUFFER, self.0);
+        }
+    }
+}
+
 
 impl Drop for Framebuffer {
     fn drop(&mut self) {

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -986,6 +986,24 @@ impl Renderbuffer {
             gl::BindRenderbuffer(gl::RENDERBUFFER, self.0);
         }
     }
+
+    pub fn storage_multisample(
+        &self,
+        samples: i32,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) {
+        unsafe {
+            gl::RenderbufferStorageMultisample(
+                gl::RENDERBUFFER,
+                samples,
+                format,
+                width as i32,
+                height as i32
+            );
+        }
+    }
 }
 
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -41,9 +41,6 @@ use std::thread;
 
 const ATLAS_SIZE: usize = 1024;
 
-// TEMP
-const NUM_SAMPLES: i32 = 2;
-
 pub struct Camera {
     pub pos: cgmath::Point3<f64>,
     pub yaw: f64,
@@ -777,7 +774,6 @@ init_shader! {
             required accum => "taccum",
             required revealage => "trevealage",
             required color => "tcolor",
-            required samples => "samples",
         },
     }
 }
@@ -850,35 +846,37 @@ impl TransInfo {
         main.bind();
 
         let fb_color = gl::Texture::new();
-        fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_color.image_2d_sample(
-            gl::TEXTURE_2D_MULTISAMPLE,
-            NUM_SAMPLES,
+        fb_color.bind(gl::TEXTURE_2D);
+        fb_color.image_2d(
+            gl::TEXTURE_2D,
+            0,
             width,
             height,
-            gl::RGBA8,
-            false,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            None,
         );
         main.texture_2d(
             gl::COLOR_ATTACHMENT_0,
-            gl::TEXTURE_2D_MULTISAMPLE,
+            gl::TEXTURE_2D,
             &fb_color,
             0,
         );
 
         let fb_depth = gl::Texture::new();
-        fb_depth.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_depth.image_2d_sample(
-            gl::TEXTURE_2D_MULTISAMPLE,
-            NUM_SAMPLES,
+        fb_depth.bind(gl::TEXTURE_2D);
+        fb_depth.image_2d(
+            gl::TEXTURE_2D,
+            0,
             width,
             height,
-            gl::DEPTH_COMPONENT24,
-            false,
+            gl::DEPTH_COMPONENT,
+            gl::UNSIGNED_BYTE,
+            None,
         );
         main.texture_2d(
             gl::DEPTH_ATTACHMENT,
-            gl::TEXTURE_2D_MULTISAMPLE,
+            gl::TEXTURE_2D,
             &fb_depth,
             0,
         );
@@ -925,13 +923,12 @@ impl TransInfo {
         gl::active_texture(1);
         self.revealage.bind(gl::TEXTURE_2D);
         gl::active_texture(2);
-        self.fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
+        self.fb_color.bind(gl::TEXTURE_2D);
 
         shader.program.use_program();
         shader.accum.set_int(0);
         shader.revealage.set_int(1);
         shader.color.set_int(2);
-        shader.samples.set_int(NUM_SAMPLES);
         self.array.bind();
         gl::draw_arrays(gl::TRIANGLES, 0, 6);
     }

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,8 +1,6 @@
 uniform sampler2D taccum;
 uniform sampler2D trevealage;
-uniform sampler2DMS tcolor;
-
-uniform int samples;
+uniform sampler2D tcolor;
 
 out vec4 fragColor;
 
@@ -12,11 +10,6 @@ void main() {
     float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
 
-    for (int i = 1; i < samples; i++) {
-        col += texelFetch(tcolor, C, i);
-    }
-    col /= float(samples);
-
     float r = accum.a;
     accum.a = aa;
     if (r >= 1.0) {
@@ -25,4 +18,5 @@ void main() {
         vec3 alp = clamp(accum.rgb / clamp(accum.a, 1e-4, 5e4), 0.0, 1.0);
         fragColor = vec4(col.rgb * r  + alp * (1.0 - r), 0.0);
     }
+    //fragColor = vec4(0.0, 1.0, 0.0, 0.0); // green test - fragment shader
 }


### PR DESCRIPTION
glTexImage2DMultisample is unavailable in [glow](https://github.com/grovesNL/glow) (porting in #262) because it is not available on WebGL, see: https://github.com/iceiix/stevenarella/pull/262#issuecomment-571399047 - as a replacement should either: 

* disable multisampling (glTexImage2D), or
* replace multisample texture with a multisample renderbuffer (glRenderbufferStorageMultisample)

See also this previous issue (one of the earliest fixed) with NUM_SAMPLES: https://github.com/iceiix/stevenarella/issues/5#issuecomment-453707500