### PR TITLE
Disable multisampled textures, glTexImage2DMultisample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,8 +790,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.6.1"
-source = "git+https://github.com/iceiix/glow?rev=b354346dee69ff0ca7ccef67f7580dfbb697423b#b354346dee69ff0ca7ccef67f7580dfbb697423b"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eac04632dc8c047fb70d658f8479583e1bb084859f67a150227769a10fc161f"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ opt-level = 1
 cfg-if = "1.0.0"
 wasm-bindgen = "0.2.69"
 winit = { version = "0.24.0", features = [ "web-sys" ]}
-glow = { git = "https://github.com/iceiix/glow", rev = "b354346dee69ff0ca7ccef67f7580dfbb697423b" }
+glow = "0.7.1"
 byteorder = "1.3.4"
 serde = "1.0.118"
 serde_json = "1.0.60"

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -14,7 +14,7 @@
 
 use glow as gl;
 use glow::{HasContext, PixelPackData, PixelUnpackData};
-use log::{error, info};
+use log::error;
 use std::mem;
 use std::ops::BitOr;
 use std::ops::{Deref, DerefMut};
@@ -365,38 +365,6 @@ impl Texture {
                 format,
                 ty,
                 pix,
-            );
-        }
-    }
-
-    pub fn image_2d_sample(
-        &self,
-        target: TextureTarget,
-        samples: i32,
-        width: u32,
-        height: u32,
-        format: TextureFormat,
-        fixed: bool,
-    ) {
-        unsafe {
-            let result: i32 = glow_context().get_parameter_i32(gl::MAX_SAMPLES);
-            let use_samples = if samples > result {
-                info!(
-                    "glTexImage2DMultisample: requested {} samples but GL_MAX_SAMPLES is {}",
-                    samples, result
-                );
-                result
-            } else {
-                samples
-            };
-            // TODO: switch to glRenderbufferStorageMultisample https://github.com/iceiix/stevenarella/pull/442
-            glow_context().tex_image_2d_multisample(
-                target,
-                use_samples,
-                format,
-                width as i32,
-                height as i32,
-                fixed,
             );
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -39,9 +39,6 @@ use std::thread;
 
 const ATLAS_SIZE: usize = 1024;
 
-// TEMP
-const NUM_SAMPLES: i32 = 2;
-
 pub struct Camera {
     pub pos: cgmath::Point3<f64>,
     pub yaw: f64,
@@ -775,7 +772,6 @@ init_shader! {
             required accum => "taccum",
             required revealage => "trevealage",
             required color => "tcolor",
-            required samples => "samples",
         },
     }
 }
@@ -847,39 +843,39 @@ impl TransInfo {
         let main = gl::Framebuffer::new();
         main.bind();
 
+        // TODO: support rendering to a multisample renderbuffer for MSAA, using glRenderbufferStorageMultisample
+        // https://github.com/iceiix/stevenarella/pull/442
         let fb_color = gl::Texture::new();
-        fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_color.image_2d_sample(
-            gl::TEXTURE_2D_MULTISAMPLE,
-            NUM_SAMPLES,
+        fb_color.bind(gl::TEXTURE_2D);
+        fb_color.image_2d(
+            gl::TEXTURE_2D,
+            0,
             width,
             height,
-            gl::RGBA8,
-            false,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            None,
         );
-        main.texture_2d(
-            gl::COLOR_ATTACHMENT_0,
-            gl::TEXTURE_2D_MULTISAMPLE,
-            &fb_color,
-            0,
-        );
+        fb_color.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR);
+        fb_color.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR);
 
+        main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &fb_color, 0);
         let fb_depth = gl::Texture::new();
-        fb_depth.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_depth.image_2d_sample(
-            gl::TEXTURE_2D_MULTISAMPLE,
-            NUM_SAMPLES,
+        fb_depth.bind(gl::TEXTURE_2D);
+        fb_depth.image_2d_ex(
+            gl::TEXTURE_2D,
+            0,
             width,
             height,
             gl::DEPTH_COMPONENT24,
-            false,
+            gl::DEPTH_COMPONENT,
+            gl::UNSIGNED_BYTE,
+            None,
         );
-        main.texture_2d(
-            gl::DEPTH_ATTACHMENT,
-            gl::TEXTURE_2D_MULTISAMPLE,
-            &fb_depth,
-            0,
-        );
+        fb_depth.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR);
+        fb_depth.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR);
+
+        main.texture_2d(gl::DEPTH_ATTACHMENT, gl::TEXTURE_2D, &fb_depth, 0);
         gl::check_framebuffer_status();
 
         gl::unbind_framebuffer();
@@ -923,13 +919,12 @@ impl TransInfo {
         gl::active_texture(1);
         self.revealage.bind(gl::TEXTURE_2D);
         gl::active_texture(2);
-        self.fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
+        self.fb_color.bind(gl::TEXTURE_2D);
 
         shader.program.use_program();
         shader.accum.set_int(0);
         shader.revealage.set_int(1);
         shader.color.set_int(2);
-        shader.samples.set_int(NUM_SAMPLES);
         self.array.bind();
         gl::draw_arrays(gl::TRIANGLES, 0, 6);
     }

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,8 +1,6 @@
 uniform sampler2D taccum;
 uniform sampler2D trevealage;
-uniform sampler2DMS tcolor;
-
-uniform int samples;
+uniform sampler2D tcolor;
 
 out vec4 fragColor;
 
@@ -11,11 +9,6 @@ void main() {
     vec4 accum = texelFetch(taccum, C, 0);
     float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
-
-    for (int i = 1; i < samples; i++) {
-        col += texelFetch(tcolor, C, i);
-    }
-    col /= float(samples);
 
     float r = accum.a;
     accum.a = aa;


### PR DESCRIPTION
Steven used multisampled textures from the beginning, but this caused
incompatibilities: https://github.com/Thinkofname/steven/issues/74.
Subsequently fixed by increasing the number of samples, but increasing
it beyond the limit caused more incompatibilities, so it was clamped to
the maximum samples reported as supported by the system.

Fast-forward to now, as part of adding WebGL support (#446), the use of
multisampled textures via the glTexImage2DMultisample() call is
unsupported on this platform. Replace the following:

* glTexImage2DMultisample -> glTexImage2D
* TEXTURE_2D_MULTISAMPLE -> TEXTURE_2D
* sampler2DMS -> sampler2D

This disables the custom multisampling anti-aliasing algorithm (MSAA)
implemented in the chunk fragment shader, increasing compatibility:

* Update to glow release, remove image_2d_sample()

MSAA may be added back at a later date using multisampled renderbuffers
instead, see #442.