### PR TITLE
Add 1.16.1+ new blocks/states

### DIFF
--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -2392,6 +2392,14 @@ define_blocks! {
             _ => false,
         },
     }
+    Chain {
+        props {
+            waterlogged: bool = [true, false],
+        },
+        data None,
+        offsets |protocol_version| { if protocol_version >= 735 { Some(if waterlogged { 1 } else { 0 }) } else { None } },
+        model { ("minecraft", "chain") },
+    }
     GlassPane {
         props {
             north: bool = [false, true],

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -717,13 +717,7 @@ define_blocks! {
     NetherGoldOre {
         props {},
         data None,
-        offsets |protocol_version| {
-            if protocol_version >= 735 {
-                Some(0)
-            } else {
-                None
-            }
-        },
+        offsets |protocol_version| { if protocol_version >= 735 { Some(0) } else { None } },
         model { ("minecraft", "nether_gold_ore") },
     }
     Log {
@@ -1400,6 +1394,12 @@ define_blocks! {
             "east" => east == (val == "true"),
             _ => false,
         },
+    }
+    SoulFire {
+        props {},
+        offsets |protocol_version| { if protocol_version >= 735 { Some(0) } else { None } },
+        model { ("minecraft", "soul_fire") },
+        collision vec![],
     }
     MobSpawner {
         props {},

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -2074,6 +2074,39 @@ define_blocks! {
             }) } else { None } },
         model { ("minecraft", "basalt") },
     }
+    PolishedBasalt {
+        props {
+            axis: Axis = [Axis::X, Axis::Y, Axis::Z],
+        },
+        data None,
+        offsets |protocol_version| { if protocol_version >= 735 { Some(
+            match axis {
+                Axis::X => 0,
+                Axis::Y => 1,
+                Axis::Z => 2,
+                _ => unreachable!()
+            }) } else { None } },
+        model { ("minecraft", "polished_basalt") },
+    }
+    SoulTorch {
+        props {},
+        data None,
+        offsets |protocol_version| { if protocol_version >= 735 { Some(0) } else { None } },
+        model { ("minecraft", "soul_torch") },
+    }
+    SoulWallTorch {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data None,
+        offsets |protocol_version| { if protocol_version >= 735 { Some(facing.offset()) } else { None } },
+        model { ("minecraft", "soul_wall_torch") },
+    }
     Glowstone {
         props {},
         material Material {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -2395,9 +2395,29 @@ define_blocks! {
     Chain {
         props {
             waterlogged: bool = [true, false],
+            axis: Axis = [Axis::X, Axis::Y, Axis::Z],
         },
         data None,
-        offsets |protocol_version| { if protocol_version >= 735 { Some(if waterlogged { 1 } else { 0 }) } else { None } },
+        offsets |protocol_version| {
+            if protocol_version >= 735 {
+                let o = if waterlogged { 1 } else { 0 };
+                if protocol_version >= 751 {
+                    Some(match axis {
+                        Axis::X => 0,
+                        Axis::Y => 1,
+                        Axis::Z => 2,
+                        _ => unreachable!()
+                        } * 2 + o)
+                } else {
+                    match axis {
+                        Axis::Y => Some(o),
+                        _ => None,
+                    }
+                }
+            } else {
+                None
+            }
+        },
         model { ("minecraft", "chain") },
     }
     GlassPane {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -2055,6 +2055,25 @@ define_blocks! {
             Point3::new(1.0, 7.0/8.0, 1.0)
         )],
     }
+    SoulSoil {
+        props {},
+        offsets |protocol_version| { if protocol_version >= 735 { Some(0) } else { None } },
+        model { ("minecraft", "soul_soil") },
+    }
+    Basalt {
+        props {
+            axis: Axis = [Axis::X, Axis::Y, Axis::Z],
+        },
+        data None,
+        offsets |protocol_version| { if protocol_version >= 735 { Some(
+            match axis {
+                Axis::X => 0,
+                Axis::Y => 1,
+                Axis::Z => 2,
+                _ => unreachable!()
+            }) } else { None } },
+        model { ("minecraft", "basalt") },
+    }
     Glowstone {
         props {},
         material Material {

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -714,6 +714,18 @@ define_blocks! {
         props {},
         model { ("minecraft", "coal_ore") },
     }
+    NetherGoldOre {
+        props {},
+        data None,
+        offsets |protocol_version| {
+            if protocol_version >= 735 {
+                Some(0)
+            } else {
+                None
+            }
+        },
+        model { ("minecraft", "nether_gold_ore") },
+    }
     Log {
         props {
             variant: TreeVariant = [


### PR DESCRIPTION
Building on https://github.com/iceiix/stevenarella/pull/469, add additional block and/or block states beyond 1.14+ to fix shifted IDs.

* 1.15 (protocol_version >= 575), use new block states from 1.15.2
* 1.16.1 (protocol_version >= 735), use new block states from 1.16.1
* 1.16.2+ (protocol_version >= 751), use new block states from 1.16.2

diffs: https://gist.github.com/iceiix/086ed124fd19744140b368d06594a109

1.15 is mostly naming fixes not so much shifts, but 1.16.1 does have shifts we need to handle