### PR TITLE
www: bundle resources statically

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -13,6 +13,7 @@ To build for wasm32-unknown-unknown, run in the top-level directory (not www):
 rustup target add wasm32-unknown-unknown
 cargo install wasm-bindgen-cli
 cargo install wasm-pack
+cp -vr resources-*/assets/minecraft/* resources/assets/minecraft && git checkout resources
 wasm-pack build --dev
 ```
 


### PR DESCRIPTION
To run on the web (#446), we need some way to get to the resources. Currently, it is conditionally-compiled out for wasm32 in src/resources.rs