### PR TITLE
forge: add FML2 protocol support (1.13.2-1.16.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ development is not in lock-step with the server version. The level of
 support varies, but the goal is to support major versions from 1.7.10
 up to the current latest major version. Occasionally, snapshots are also supported.
 
-Forge servers are currently supported on 1.7.10 - 1.12.2.
+Forge servers are supported on 1.7.10 - 1.12.2 (FML) and 1.13.2 - 1.16.5 (FML2).
 
 Support for older protocols will _not_ be dropped as newer protocols are added.
 

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 
 [[package]]
 name = "serde_json"

--- a/protocol/src/protocol/forge.rs
+++ b/protocol/src/protocol/forge.rs
@@ -223,8 +223,11 @@ pub mod fml2 {
     }
 
     impl Serializable for Registry {
-        fn read_from<R: io::Read>(_buf: &mut R) -> Result<Self, Error> {
-            unimplemented!()
+        fn read_from<R: io::Read>(buf: &mut R) -> Result<Self, Error> {
+            Ok(Registry {
+                name: Serializable::read_from(buf)?,
+                marker: "".to_string() // not in ModList
+            })
         }
 
         fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
@@ -238,7 +241,7 @@ pub mod fml2 {
         ModList {
             mod_names: LenPrefixed<VarInt, String>,
             channels: LenPrefixed<VarInt, Channel>,
-            registries: LenPrefixed<VarInt, String>,
+            registries: LenPrefixed<VarInt, Registry>,
         },
 
         ModListReply {

--- a/protocol/src/protocol/forge.rs
+++ b/protocol/src/protocol/forge.rs
@@ -191,3 +191,118 @@ impl Serializable for FmlHs {
         }
     }
 }
+
+pub mod fml2 {
+    // https://wiki.vg/Minecraft_Forge_Handshake#FML2_protocol_.281.13_-_Current.29
+    use super::*;
+
+    #[derive(Clone, Default, Debug)]
+    pub struct Channel {
+        pub name: String,
+        pub version: String,
+    }
+
+    impl Serializable for Channel {
+        fn read_from<R: io::Read>(buf: &mut R) -> Result<Self, Error> {
+            Ok(Channel {
+                name: Serializable::read_from(buf)?,
+                version: Serializable::read_from(buf)?,
+            })
+        }
+
+        fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
+            self.name.write_to(buf)?;
+            self.version.write_to(buf)
+        }
+    }
+
+    #[derive(Clone, Default, Debug)]
+    pub struct Registry {
+        pub name: String,
+        pub marker: String,
+    }
+
+    impl Serializable for Registry {
+        fn read_from<R: io::Read>(_buf: &mut R) -> Result<Self, Error> {
+            unimplemented!()
+        }
+
+        fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
+            self.name.write_to(buf)?;
+            self.marker.write_to(buf)
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum FmlHandshake {
+        ModList {
+            mod_names: LenPrefixed<VarInt, String>,
+            channels: LenPrefixed<VarInt, Channel>,
+            registries: LenPrefixed<VarInt, String>,
+        },
+
+        ModListReply {
+            mod_names: LenPrefixed<VarInt, String>,
+            channels: LenPrefixed<VarInt, Channel>,
+            registries: LenPrefixed<VarInt, Registry>,
+        },
+
+        ServerRegistry {
+            name: String,
+            snapshot_present: bool,
+            snapshot: Vec<u8>,
+        },
+
+        ConfigurationData {
+            filename: String,
+            contents: Vec<u8>,
+        },
+
+        Acknowledgement,
+    }
+
+    impl FmlHandshake {
+        pub fn packet_by_id<R: io::Read>(id: i32, buf: &mut R) -> Result<Self, Error> {
+            Ok(match id {
+                1 => FmlHandshake::ModList {
+                    mod_names: Serializable::read_from(buf)?,
+                    channels: Serializable::read_from(buf)?,
+                    registries: Serializable::read_from(buf)?,
+                },
+                3 => FmlHandshake::ServerRegistry {
+                    name: Serializable::read_from(buf)?,
+                    snapshot_present: Serializable::read_from(buf)?,
+                    snapshot: Serializable::read_from(buf)?,
+                },
+                4 => FmlHandshake::ConfigurationData {
+                    filename: Serializable::read_from(buf)?,
+                    contents: Serializable::read_from(buf)?,
+                },
+                _ => unimplemented!(),
+            })
+        }
+    }
+
+    impl Serializable for FmlHandshake {
+        fn read_from<R: io::Read>(_buf: &mut R) -> Result<Self, Error> {
+            unimplemented!()
+        }
+
+        fn write_to<W: io::Write>(&self, buf: &mut W) -> Result<(), Error> {
+            match self {
+                FmlHandshake::ModListReply {
+                    mod_names,
+                    channels,
+                    registries,
+                } => {
+                    VarInt(2).write_to(buf)?;
+                    mod_names.write_to(buf)?;
+                    channels.write_to(buf)?;
+                    registries.write_to(buf)
+                }
+                FmlHandshake::Acknowledgement => VarInt(99).write_to(buf),
+                _ => unimplemented!(),
+            }
+        }
+    }
+}

--- a/protocol/src/protocol/forge.rs
+++ b/protocol/src/protocol/forge.rs
@@ -226,7 +226,7 @@ pub mod fml2 {
         fn read_from<R: io::Read>(buf: &mut R) -> Result<Self, Error> {
             Ok(Registry {
                 name: Serializable::read_from(buf)?,
-                marker: "".to_string() // not in ModList
+                marker: "".to_string(), // not in ModList
             })
         }
 

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1224,6 +1224,7 @@ impl Conn {
 
         // For modded servers, get the list of Forge mods installed
         let mut forge_mods: std::vec::Vec<crate::protocol::forge::ForgeMod> = vec![];
+        let mut fml_network_version: Option<i64> = None;
         if let Some(modinfo) = val.get("modinfo") {
             if let Some(modinfo_type) = modinfo.get("type") {
                 if modinfo_type == "FML" {
@@ -1240,6 +1241,7 @@ impl Conn {
                                         .push(crate::protocol::forge::ForgeMod { modid, version });
                                 }
                             }
+                            fml_network_version = Some(1);
                         }
                     }
                 } else {
@@ -1267,6 +1269,7 @@ impl Conn {
                     }
                 }
             }
+            fml_network_version = Some(forge_data.get("fmlNetworkVersion").unwrap().as_i64().unwrap());
         }
 
         Ok((
@@ -1301,6 +1304,7 @@ impl Conn {
                     .and_then(Value::as_str)
                     .map(|v| v.to_owned()),
                 forge_mods,
+                fml_network_version,
             },
             ping,
         ))
@@ -1352,6 +1356,7 @@ pub struct Status {
     pub description: format::Component,
     pub favicon: Option<String>,
     pub forge_mods: Vec<crate::protocol::forge::ForgeMod>,
+    pub fml_network_version: Option<i64>,
 }
 
 #[derive(Debug)]

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1133,6 +1133,14 @@ impl Conn {
     }
 
     pub fn write_login_plugin_response(&mut self, message_id: VarInt, successful: bool, data: &[u8]) -> Result<(), Error> {
+        if is_network_debug() {
+            debug!(
+                "Sending login plugin message: message_id={:?}, successful={:?}, data={:?}",
+                message_id,
+                successful,
+                data,
+            );
+        }
         debug_assert!(self.state == State::Login);
         self.write_packet(packet::login::serverbound::LoginPluginResponse {
             message_id,

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1269,7 +1269,13 @@ impl Conn {
                     }
                 }
             }
-            fml_network_version = Some(forge_data.get("fmlNetworkVersion").unwrap().as_i64().unwrap());
+            fml_network_version = Some(
+                forge_data
+                    .get("fmlNetworkVersion")
+                    .unwrap()
+                    .as_i64()
+                    .unwrap(),
+            );
         }
 
         Ok((

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1132,20 +1132,23 @@ impl Conn {
         self.write_plugin_message("FML|HS", &buf)
     }
 
-    pub fn write_login_plugin_response(&mut self, message_id: VarInt, successful: bool, data: &[u8]) -> Result<(), Error> {
+    pub fn write_login_plugin_response(
+        &mut self,
+        message_id: VarInt,
+        successful: bool,
+        data: &[u8],
+    ) -> Result<(), Error> {
         if is_network_debug() {
             debug!(
                 "Sending login plugin message: message_id={:?}, successful={:?}, data={:?}",
-                message_id,
-                successful,
-                data,
+                message_id, successful, data,
             );
         }
         debug_assert!(self.state == State::Login);
         self.write_packet(packet::login::serverbound::LoginPluginResponse {
             message_id,
             successful,
-            data: data.to_vec()
+            data: data.to_vec(),
         })
     }
 
@@ -1254,7 +1257,6 @@ impl Conn {
     }
 
     pub fn set_compresssion(&mut self, threshold: i32) {
-        println!("set_compression {:?}", threshold);
         self.compression_threshold = threshold;
     }
 

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1163,7 +1163,7 @@ impl Conn {
             VarInt(inner_buf.len() as i32).write_to(&mut outer_buf)?;
             inner_buf.write_to(&mut outer_buf)?;
 
-            self.write_login_plugin_response(message_id, true, &inner_buf)
+            self.write_login_plugin_response(message_id, true, &outer_buf)
         } else {
             unimplemented!() // successful: false, no payload
         }

--- a/protocol/src/protocol/packet.rs
+++ b/protocol/src/protocol/packet.rs
@@ -3135,6 +3135,12 @@ pub enum CommandProperty {
     EntitySummon,
     Dimension,
     UUID,
+    ForgeModId {
+        modid: String,
+    },
+    ForgeEnum {
+        cls: String,
+    }
 }
 
 impl Serializable for CommandNode {
@@ -3264,6 +3270,12 @@ impl Serializable for CommandNode {
                 "minecraft:entity_summon" => CommandProperty::EntitySummon,
                 "minecraft:dimension" => CommandProperty::Dimension,
                 "minecraft:uuid" => CommandProperty::UUID,
+                "forge:modid" => CommandProperty::ForgeModId {
+                    modid: Serializable::read_from(buf)?,
+                },
+                "forge:enum" => CommandProperty::ForgeEnum {
+                    cls: Serializable::read_from(buf)?,
+                },
                 _ => panic!("unsupported command node parser {}", parse),
             })
         } else {

--- a/protocol/src/protocol/packet.rs
+++ b/protocol/src/protocol/packet.rs
@@ -3135,9 +3135,7 @@ pub enum CommandProperty {
     EntitySummon,
     Dimension,
     UUID,
-    ForgeModId {
-        modid: String,
-    },
+    ForgeModId,
     ForgeEnum {
         cls: String,
     }
@@ -3270,9 +3268,7 @@ impl Serializable for CommandNode {
                 "minecraft:entity_summon" => CommandProperty::EntitySummon,
                 "minecraft:dimension" => CommandProperty::Dimension,
                 "minecraft:uuid" => CommandProperty::UUID,
-                "forge:modid" => CommandProperty::ForgeModId {
-                    modid: Serializable::read_from(buf)?,
-                },
+                "forge:modid" => CommandProperty::ForgeModId,
                 "forge:enum" => CommandProperty::ForgeEnum {
                     cls: Serializable::read_from(buf)?,
                 },

--- a/protocol/src/protocol/packet.rs
+++ b/protocol/src/protocol/packet.rs
@@ -3138,7 +3138,7 @@ pub enum CommandProperty {
     ForgeModId,
     ForgeEnum {
         cls: String,
-    }
+    },
 }
 
 impl Serializable for CommandNode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ pub struct Game {
 
 impl Game {
     pub fn connect_to(&mut self, address: &str) {
-        let (protocol_version, forge_mods) =
+        let (protocol_version, forge_mods, fml_network_version) =
             match protocol::Conn::new(&address, self.default_protocol_version)
                 .and_then(|conn| conn.do_status())
             {
@@ -100,14 +100,14 @@ impl Game {
                         "Detected server protocol version {}",
                         res.0.version.protocol
                     );
-                    (res.0.version.protocol, res.0.forge_mods)
+                    (res.0.version.protocol, res.0.forge_mods, res.0.fml_network_version)
                 }
                 Err(err) => {
                     warn!(
                         "Error pinging server {} to get protocol version: {:?}, defaulting to {}",
                         address, err, self.default_protocol_version
                     );
-                    (self.default_protocol_version, vec![])
+                    (self.default_protocol_version, vec![], None)
                 }
             };
 
@@ -127,6 +127,7 @@ impl Game {
                 &address,
                 protocol_version,
                 forge_mods,
+                fml_network_version,
             ))
             .unwrap();
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,11 @@ impl Game {
                         "Detected server protocol version {}",
                         res.0.version.protocol
                     );
-                    (res.0.version.protocol, res.0.forge_mods, res.0.fml_network_version)
+                    (
+                        res.0.version.protocol,
+                        res.0.forge_mods,
+                        res.0.fml_network_version,
+                    )
                 }
                 Err(err) => {
                     warn!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,7 @@ use crate::types::Gamemode;
 use crate::world;
 use crate::world::block;
 use cgmath::prelude::*;
-use log::{debug, error, warn};
+use log::{debug, error, warn, info};
 use rand::{self, Rng};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
@@ -267,33 +267,35 @@ impl Server {
                                     let packet =
                                         forge::fml2::FmlHandshake::packet_by_id(id, &mut data)?;
                                     use forge::fml2::FmlHandshake::*;
+                                    use protocol::Serializable;
                                     match packet {
                                         ModList {
                                             mod_names,
                                             channels,
                                             registries,
                                         } => {
-                                            println!("ModList mod_names={:?} channels={:?} registries={:?}", mod_names, channels, registries);
-                                            // TODO: send ModListReply
+                                            info!("ModList mod_names={:?} channels={:?} registries={:?}", mod_names, channels, registries);
+                                            ModListReply {
+                                                mod_names,
+                                                channels,
+                                                registries,
+                                            }.write_to(&mut write)?
                                         }
                                         ServerRegistry {
                                             name,
-                                            snapshot_present,
-                                            snapshot: _snapshot,
+                                            snapshot_present: _,
+                                            snapshot: _,
                                         } => {
-                                            println!(
-                                                "ServerRegistry {:?} snapshot_present {:?}",
-                                                name, snapshot_present
-                                            );
-                                            // TODO: send Acknowledgement
+                                            info!("ServerRegistry {:?}", name);
+                                            Acknowledgement.write_to(&mut write)?
                                         }
                                         ConfigurationData { filename, contents } => {
-                                            println!(
+                                            info!(
                                                 "ConfigurationData filename={:?} contents={}",
                                                 filename,
                                                 String::from_utf8_lossy(&contents)
                                             );
-                                            // TODO: send Acknowledgement
+                                            Acknowledgement.write_to(&mut write)?
                                         }
                                         _ => unimplemented!(),
                                     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,7 @@ use crate::types::Gamemode;
 use crate::world;
 use crate::world::block;
 use cgmath::prelude::*;
-use log::{debug, error, warn, info};
+use log::{debug, error, info, warn};
 use rand::{self, Rng};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
@@ -279,7 +279,8 @@ impl Server {
                                                 mod_names,
                                                 channels,
                                                 registries,
-                                            }.write_to(&mut write)?
+                                            }
+                                            .write_to(&mut write)?
                                         }
                                         ServerRegistry {
                                             name,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -110,14 +110,17 @@ impl Server {
         address: &str,
         protocol_version: i32,
         forge_mods: Vec<forge::ForgeMod>,
+        fml_network_version: Option<i64>,
     ) -> Result<Server, protocol::Error> {
         let mut conn = protocol::Conn::new(address, protocol_version)?;
 
-        let tag = if !forge_mods.is_empty() {
-            "\0FML\0"
-        } else {
-            ""
+        let tag = match fml_network_version {
+            Some(1) => "\0FML\0",
+            Some(2) => "\0FML2\0",
+            None => "",
+            _ => panic!("unsupported FML network version: {:?}", fml_network_version),
         };
+
         let host = conn.host.clone() + tag;
         let port = conn.port;
         conn.write_packet(protocol::packet::handshake::serverbound::Handshake {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -253,9 +253,13 @@ impl Server {
                 }
                 protocol::packet::Packet::LoginPluginRequest(val) => match val.channel.as_ref() {
                     "fml:loginwrapper" => {
-                        println!("fml:loginwrapper packet: message_id={:?}, channel={:?}, data={:?} bytes", val.message_id, val.channel, val.data.len());
+                        debug!("fml:loginwrapper packet: message_id={:?}, channel={:?}, data={:?} bytes", val.message_id, val.channel, val.data);
+                        let mut cursor = std::io::Cursor::new(val.data);
+                        let channel: String = protocol::Serializable::read_from(&mut cursor)?;
+                        debug!("fml:loginwrapper inner channel = {:?}", channel); // fml:handshake
+
                         let (id, data) = protocol::Conn::read_raw_packet_from(
-                            &mut std::io::Cursor::new(val.data),
+                            &mut cursor,
                             compression_threshold,
                         )?;
                         println!("inner packet id = {:?}, data = {:?} bytes", id, data);


### PR DESCRIPTION
Add FML2 protocol support, Forge on 1.13 - Current https://github.com/iceiix/stevenarella/issues/400

https://wiki.vg/Minecraft_Forge_Handshake#FML2_protocol_.281.13_-_Current.29

Extends #88 #134 Forge FML (1) support