### PR TITLE
fix block placement in 1.16

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -799,23 +799,25 @@ impl Server {
                 target::test_block,
             ) {
                 if self.protocol_version >= 477 {
-                    self.write_packet(packet::play::serverbound::PlayerBlockPlacement_insideblock {
-                        location: pos,
-                        face: protocol::VarInt(match face {
-                            Direction::Down => 0,
-                            Direction::Up => 1,
-                            Direction::North => 2,
-                            Direction::South => 3,
-                            Direction::West => 4,
-                            Direction::East => 5,
-                            _ => unreachable!(),
-                        }),
-                        hand: protocol::VarInt(0),
-                        cursor_x: at.x as f32,
-                        cursor_y: at.y as f32,
-                        cursor_z: at.z as f32,
-                        inside_block: false,
-                    });
+                    self.write_packet(
+                        packet::play::serverbound::PlayerBlockPlacement_insideblock {
+                            location: pos,
+                            face: protocol::VarInt(match face {
+                                Direction::Down => 0,
+                                Direction::Up => 1,
+                                Direction::North => 2,
+                                Direction::South => 3,
+                                Direction::West => 4,
+                                Direction::East => 5,
+                                _ => unreachable!(),
+                            }),
+                            hand: protocol::VarInt(0),
+                            cursor_x: at.x as f32,
+                            cursor_y: at.y as f32,
+                            cursor_z: at.z as f32,
+                            inside_block: false,
+                        },
+                    );
                 } else if self.protocol_version >= 315 {
                     self.write_packet(packet::play::serverbound::PlayerBlockPlacement_f32 {
                         location: pos,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -798,7 +798,25 @@ impl Server {
                 renderer.view_vector.cast().unwrap(),
                 target::test_block,
             ) {
-                if self.protocol_version >= 315 {
+                if self.protocol_version >= 477 {
+                    self.write_packet(packet::play::serverbound::PlayerBlockPlacement_insideblock {
+                        location: pos,
+                        face: protocol::VarInt(match face {
+                            Direction::Down => 0,
+                            Direction::Up => 1,
+                            Direction::North => 2,
+                            Direction::South => 3,
+                            Direction::West => 4,
+                            Direction::East => 5,
+                            _ => unreachable!(),
+                        }),
+                        hand: protocol::VarInt(0),
+                        cursor_x: at.x as f32,
+                        cursor_y: at.y as f32,
+                        cursor_z: at.z as f32,
+                        inside_block: false,
+                    });
+                } else if self.protocol_version >= 315 {
                     self.write_packet(packet::play::serverbound::PlayerBlockPlacement_f32 {
                         location: pos,
                         face: protocol::VarInt(match face {


### PR DESCRIPTION
placing a block in an 1.16 server causes a panic

this line https://github.com/iceiix/stevenarella/blob/master/protocol/src/protocol/packet.rs#L519 tells me that after 1.14 that packet was different, the correct packet was added in the right mouse button handler