### PR TITLE
Remove mention of Freenode channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In action: http://gfycat.com/NeedyElaborateGypsymoth
 
 ## Community
 
-IRC channels: `#stevenarella` on [irc.freenode.net](https://freenode.net), or `#stevenarella` on [irc.esper.net](https://esper.net).
+IRC channel: `#stevenarella` on [irc.esper.net](https://esper.net).
 
 Discussion forum: [https://github.com/iceiix/stevenarella/discussions](https://github.com/iceiix/stevenarella/discussions).
 


### PR DESCRIPTION
As most people know, Freenode has changed owners and a lot of stuff
happened since. No need to go into details here, but all IRC channels on
the network are gone and control by channel operators is lost.

The channel wasn't really used anyway, which is sad. Is the Espernet channel actively used? The fact that it isn't reachable from Matrix is a blocker for me to use it as least, having a channel on for example OFTC or the new [Libera.Chat](https://libera.chat) instead would be nice.