### PR TITLE
Fixed a focusing bug in the settings

### DIFF
--- a/src/screen/settings_menu.rs
+++ b/src/screen/settings_menu.rs
@@ -308,7 +308,6 @@ impl super::Screen for VideoSettingsMenu {
             done_button.add_text(txt);
             done_button.add_click_func(|_, game| {
                 game.screen_sys.pop_screen();
-                game.focused = true;
                 true
             });
         }
@@ -394,7 +393,6 @@ impl super::Screen for AudioSettingsMenu {
             done_button.add_text(txt);
             done_button.add_click_func(|_, game| {
                 game.screen_sys.pop_screen();
-                game.focused = true;
                 true
             });
         }


### PR DESCRIPTION
The game was previously focused after clicking the done button in the individual settings, which would cause the game to be focused while still in the main settings menu.