### PR TITLE
Fix transparency ingame

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -448,7 +448,6 @@ impl Renderer {
         gl::unbind_framebuffer();
         gl::disable(gl::DEPTH_TEST);
         gl::clear(gl::ClearFlags::Color);
-        gl::disable(gl::BLEND);
         trans.draw(&self.trans_shader);
 
         gl::enable(gl::DEPTH_TEST);


### PR DESCRIPTION
The transparency will still be present in the esc menu and the server list, but in game it will be gone.