### PR TITLE
GitHub Actions: manually run clippy if resource not accessible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,11 +21,22 @@ jobs:
       - name: Build binary
         run: |
           cargo build --verbose --release
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1.0.7
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1.0.7
+        if: steps.check_permissions.outputs.has-permission
+        with:
           args: --all-targets -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --all-targets -- -D warnings
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Upload binary

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Stevenarella
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Ficeiix%2Fstevenarella%2Fbadge%3Fref%3Dmaster&style=plastic)](https://actions-badge.atrox.dev/iceiix/stevenarella/goto?ref=master)
+[![Build](https://github.com/iceiix/stevenarella/actions/workflows/build.yaml/badge.svg)](https://github.com/iceiix/stevenarella/actions/workflows/build.yaml)
 
 Multi-protocol Minecraft-compatible client written in Rust.
 


### PR DESCRIPTION
actions-rs/clippy-check is failing for a long time now, all recent pull requests from dependabot, example: https://github.com/iceiix/stevenarella/pull/658

There's a workaround at https://github.com/actions-rs/clippy-check/issues/2#issuecomment-807878478 to run clippy "manually" without actions-rs/clippy-check