### PR TITLE
impl From<Packet types> for Packet

### DIFF
--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -129,9 +129,9 @@ macro_rules! state_packets {
                             Result::Ok(())
                         }
                     }
-                    impl Into<Packet> for $name {
-                        fn into(self) -> Packet {
-                            Packet::$name(self)
+                    impl From<$name> for Packet {
+                        fn from(v: $name) -> Packet {
+                            Packet::$name(v)
                         }
                     }
                 )*

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -93,6 +93,7 @@ macro_rules! state_packets {
             pub mod $dir {
                 #![allow(unused_imports)]
                 use crate::protocol::*;
+                use crate::protocol::packet::Packet;
                 use std::io;
                 use crate::format;
                 use crate::nbt;
@@ -126,6 +127,11 @@ macro_rules! state_packets {
                             )+
 
                             Result::Ok(())
+                        }
+                    }
+                    impl Into<Packet> for $name {
+                        fn into(self) -> Packet {
+                            Packet::$name(self)
                         }
                     }
                 )*


### PR DESCRIPTION
Without impl Into, I have to write something like
```rust
  let pkt = Packet::ClientSettings(
    packet::play::serverbound::ClientSettings {
      locale: "en_GB".to_string(),
      view_distance: 2,
      chat_mode: protocol::VarInt(0),
      chat_colors: false,
      displayed_skin_parts: 0,
      main_hand: protocol::VarInt(0),
    }
  );
```
This commit makes the following code possible
```rust
  let pkt: Packet = packet::play::serverbound::ClientSettings {
      locale: "en_GB".to_string(),
      view_distance: 2,
      chat_mode: protocol::VarInt(0),
      chat_colors: false,
      displayed_skin_parts: 0,
      main_hand: protocol::VarInt(0),
  }.into();
```
It's more tidy